### PR TITLE
ReflexGame: ensure a deterministic display

### DIFF
--- a/xtext/org.icyphy.linguafranca/src/example/ReflexGame/ReflexGame.lf
+++ b/xtext/org.icyphy.linguafranca/src/example/ReflexGame/ReflexGame.lf
@@ -39,6 +39,7 @@ reactor RandomSource(min_time:time(2 sec), max_time:time(5 sec)) {
     reaction(prompt) -> out, prompt {=
         self->count++;
         printf("%d. Hit Return or Enter!", self->count);
+        fflush(stdout);
         set(out, self->count);
     =}
     reaction(another) -> prompt {=


### PR DESCRIPTION
Without an explicit flush of the standard output, the message
  "Hit Return or Enter!"
may not be visible, because the stdio buffers are not necessarily
flushed. We now ensure that this message is always visible.