### PR TITLE
Changed analyzeResource and refreshProject to work for windows.

### DIFF
--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -968,9 +968,16 @@ abstract class GeneratorBase {
         if (mode == Mode.INTEGRATED) {
             // Find name of current project
             val id = "((:?[a-z]|[A-Z]|_\\w)*)";
-            val pattern = Pattern.compile(
+            var pattern = Pattern.compile("");
+            if (File.separator.equals("/")) { //linux file separator
+				Pattern.compile(
                 "platform:" + File.separator + "resource" + File.separator +
                     id + File.separator);
+			}else{ //windows file separator
+				pattern = Pattern.compile(
+                "platform:" + File.separator + File.separator + "resource" + File.separator + File.separator +
+                    id + File.separator + File.separator );
+			}
             val matcher = pattern.matcher(code);
             var projName = ""
             if (matcher.find()) {
@@ -1249,12 +1256,12 @@ abstract class GeneratorBase {
             System.err.println(
                 "ERROR: Source file protocol is not recognized: " + path);
         }
-        var lastSlash = sourceFile.lastIndexOf('/')
-        if (lastSlash >= 0) {
-            filename = sourceFile.substring(lastSlash + 1)
-            directory = sourceFile.substring(0, lastSlash)
-        }
+        
         // Strip the filename of the extension.
+        var File f = new File(sourceFile);
+        filename = f.getName();
+        directory = f.getParent();
+       
         if (filename.endsWith('.lf')) {
             filename = filename.substring(0, filename.length - 3)
         }


### PR DESCRIPTION
The Hello World example in https://github.com/icyphy/lingua-franca/wiki/Downloading-and-Building#building-the-ide does not seem to work in windows.

There are compile errors: null pointer and pattern matching errors in /org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend when executing in windows environment. 

Suggest changing the following
1) `private def analyzeResource(Resource resource)` function
use File object to get file name and directory rather than using finding the last '/' so that the code works on all platforms.

2) `protected def refreshProject()` function
Test for the File.seprator to determine if it is running on Unix based or Windows based systems. If the system is running on windows add an extra File.separator to each File.separator (i.e., "\\") since the path separator used by windows "\\" is an escape character.