### PR TITLE
Dependency Update for Diagrams

### DIFF
--- a/xtext/org.icyphy.linguafranca.diagram/META-INF/MANIFEST.MF
+++ b/xtext/org.icyphy.linguafranca.diagram/META-INF/MANIFEST.MF
@@ -6,13 +6,13 @@ Bundle-Version: 1.0.0.qualifier
 Automatic-Module-Name: org.icyphy.linguafranca.diagram
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
-Require-Bundle: de.cau.cs.kieler.klighd;bundle-version="0.44.0",
- de.cau.cs.kieler.klighd.krendering.extensions;bundle-version="0.44.0",
+Require-Bundle: de.cau.cs.kieler.klighd;bundle-version="1.1.0",
+ de.cau.cs.kieler.klighd.krendering.extensions;bundle-version="1.1.0",
  com.google.guava,
  org.eclipse.xtext.xbase.lib,
  org.eclipse.xtend.lib,
  org.eclipse.xtend.lib.macro,
  org.icyphy.linguafranca;bundle-version="1.0.0",
- org.eclipse.elk.core;bundle-version="0.4.0",
- org.eclipse.elk.alg.layered;bundle-version="0.4.0"
+ org.eclipse.elk.core;bundle-version="0.6.0",
+ org.eclipse.elk.alg.layered;bundle-version="0.6.0"
 Bundle-Vendor: iCyPhy Project, University of California, Berkeley

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/LinguaFrancaSynthesis.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/LinguaFrancaSynthesis.xtend
@@ -34,7 +34,7 @@ import javax.inject.Inject
 import org.eclipse.elk.alg.layered.options.FixedAlignment
 import org.eclipse.elk.alg.layered.options.LayerConstraint
 import org.eclipse.elk.alg.layered.options.LayeredOptions
-import org.eclipse.elk.alg.layered.p4nodes.bk.EdgeStraighteningStrategy
+import org.eclipse.elk.alg.layered.options.EdgeStraighteningStrategy
 import org.eclipse.elk.core.math.ElkPadding
 import org.eclipse.elk.core.math.KVector
 import org.eclipse.elk.core.options.BoxLayouterOptions

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/AbstractAction.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/AbstractAction.xtend
@@ -1,0 +1,25 @@
+package org.icyphy.linguafranca.diagram.synthesis.action
+
+import de.cau.cs.kieler.klighd.IAction
+import de.cau.cs.kieler.klighd.internal.util.KlighdInternalProperties
+import de.cau.cs.kieler.klighd.kgraph.KGraphElement
+import de.cau.cs.kieler.klighd.kgraph.KNode
+import org.icyphy.linguaFranca.Reactor
+
+abstract class AbstractAction implements IAction {
+	
+	def Object sourceElement(KGraphElement elem) {
+		return elem.getProperty(KlighdInternalProperties.MODEL_ELEMEMT)
+	}
+	
+	def boolean sourceIsReactor(KNode node) {
+		return node.sourceElement() instanceof Reactor
+	}
+	
+	def Reactor sourceAsReactor(KNode node) {
+		if (node.sourceIsReactor()) {
+			return node.sourceElement() as Reactor
+		}
+		return null
+	}
+}

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/CollapseAllReactorsAction.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/CollapseAllReactorsAction.xtend
@@ -2,20 +2,19 @@ package org.icyphy.linguafranca.diagram.synthesis.action
 
 import de.cau.cs.kieler.klighd.IAction
 import de.cau.cs.kieler.klighd.kgraph.KNode
-import org.icyphy.linguaFranca.Reactor
 import org.icyphy.linguafranca.diagram.synthesis.LinguaFrancaSynthesis
 
 import static extension de.cau.cs.kieler.klighd.util.ModelingUtil.*
 import static extension org.icyphy.linguafranca.diagram.synthesis.action.MemorizingExpandCollapseAction.*
 
-class CollapseAllReactorsAction implements IAction {
+class CollapseAllReactorsAction extends AbstractAction {
     
     public static val ID = "org.icyphy.linguafranca.diagram.synthesis.action.CollapseAllReactorsAction"
     
     override execute(ActionContext context) {
         val vc = context.viewContext
-        for (node : vc.viewModel.eAllContentsOfType(KNode).filter[vc.getSourceElement(it) instanceof Reactor].toIterable) {
-        	if (!(vc.getSourceElement(node) as Reactor).main) { // Do not collapse main reactor
+        for (node : vc.viewModel.eAllContentsOfType(KNode).filter[sourceIsReactor].toIterable) {
+        	if (!node.sourceAsReactor().main) { // Do not collapse main reactor
             	node.setExpansionState(node.getProperty(LinguaFrancaSynthesis.REACTOR_INSTANCE), vc.viewer, false)
             }
         }

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/ExpandAllReactorsAction.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/ExpandAllReactorsAction.xtend
@@ -2,19 +2,18 @@ package org.icyphy.linguafranca.diagram.synthesis.action
 
 import de.cau.cs.kieler.klighd.IAction
 import de.cau.cs.kieler.klighd.kgraph.KNode
-import org.icyphy.linguaFranca.Reactor
 import org.icyphy.linguafranca.diagram.synthesis.LinguaFrancaSynthesis
 
 import static extension de.cau.cs.kieler.klighd.util.ModelingUtil.*
 import static extension org.icyphy.linguafranca.diagram.synthesis.action.MemorizingExpandCollapseAction.*
 
-class ExpandAllReactorsAction implements IAction {
+class ExpandAllReactorsAction extends AbstractAction {
     
     public static val ID = "org.icyphy.linguafranca.diagram.synthesis.action.ExpandAllReactorsAction"
     
     override execute(ActionContext context) {
         val vc = context.viewContext
-        for (node : vc.viewModel.eAllContentsOfType(KNode).filter[vc.getSourceElement(it) instanceof Reactor].toIterable) {
+        for (node : vc.viewModel.eAllContentsOfType(KNode).filter[sourceIsReactor].toIterable) {
             node.setExpansionState(node.getProperty(LinguaFrancaSynthesis.REACTOR_INSTANCE), vc.viewer, true)
         }
         return IAction.ActionResult.createResult(true);

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/MemorizingExpandCollapseAction.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/MemorizingExpandCollapseAction.xtend
@@ -18,11 +18,11 @@ import de.cau.cs.kieler.klighd.SynthesisOption
 import de.cau.cs.kieler.klighd.kgraph.KNode
 import java.util.WeakHashMap
 import org.eclipse.emf.ecore.EObject
-
-import static extension com.google.common.base.Preconditions.*
 import org.icyphy.linguafranca.diagram.synthesis.LinguaFrancaSynthesis
 
-class MemorizingExpandCollapseAction implements IAction {
+import static extension com.google.common.base.Preconditions.*
+
+class MemorizingExpandCollapseAction extends AbstractAction {
     
     public static val MEM_EXPAND_COLLAPSE_ACTION_ID = "org.icyphy.linguafranca.diagram.synthesis.action.MemorizingExpandCollapseAction"
     
@@ -64,7 +64,7 @@ class MemorizingExpandCollapseAction implements IAction {
         val vc = context.viewContext
         val v = vc.viewer 
         val node = context.KNode
-        val source = vc.getSourceElement(node)
+        val source = node.sourceElement()
         
         if (source instanceof EObject) {
         	node.setExpansionState(node.getProperty(LinguaFrancaSynthesis.REACTOR_INSTANCE)?:source, v, !v.isExpanded(node)) // toggle

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/ShowCycleAction.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/action/ShowCycleAction.xtend
@@ -2,13 +2,12 @@ package org.icyphy.linguafranca.diagram.synthesis.action
 
 import de.cau.cs.kieler.klighd.IAction
 import de.cau.cs.kieler.klighd.kgraph.KNode
-import org.icyphy.linguaFranca.Reactor
 import org.icyphy.linguafranca.diagram.synthesis.LinguaFrancaSynthesis
 
 import static extension de.cau.cs.kieler.klighd.util.ModelingUtil.*
 import static extension org.icyphy.linguafranca.diagram.synthesis.action.MemorizingExpandCollapseAction.*
 
-class ShowCycleAction implements IAction {
+class ShowCycleAction extends AbstractAction {
     
     public static val ID = "org.icyphy.linguafranca.diagram.synthesis.action.ShowCycleAction"
     
@@ -23,8 +22,7 @@ class ShowCycleAction implements IAction {
         // Expand only errors
         val cycleNodes = <KNode>newHashSet()
         cycleNodes += vc.viewModel.eAllContentsOfType(KNode).filter[
-        	getProperty(LinguaFrancaSynthesis.DEPENDENCY_CYCLE) &&
-        	vc.getSourceElement(it) instanceof Reactor
+        	getProperty(LinguaFrancaSynthesis.DEPENDENCY_CYCLE) && sourceIsReactor
         ].toIterable
         // include parents
         val check = <KNode>newLinkedList(cycleNodes)


### PR DESCRIPTION
These changes update the diagrams plugin to the API of the latest Klighd/ELK release.

Note that, as soon as the PR is merged, everyone has to update their development eclipse to get the latest release. Otherwise there will be compilation errors.

I do not know if the diagram plugin is build in CI and which update site is used there but the build might break.