### PR TITLE
After

### DIFF
--- a/test/Cpp/GenericDelay.lf
+++ b/test/Cpp/GenericDelay.lf
@@ -1,0 +1,26 @@
+target Cpp;
+
+import DelayInt.lf;
+
+reactor GenericDelay<T>(delay:time(0)) {
+    output out:T;
+    input in:T;
+    logical action a(delay):T;
+    
+    reaction (a) -> out {=
+        out.set(a.get());
+    =}
+    
+    reaction (in) -> a {=
+        a.schedule(in.get());
+    =}
+}
+
+main reactor GenericDelayTest {
+    d = new GenericDelay<int>(delay=100 msec);
+    test = new Test();
+    d.out -> test.in; 
+    reaction(startup) -> d.in {=
+        d.in.set(42);
+    =}
+}

--- a/test/TS/After.lf
+++ b/test/TS/After.lf
@@ -4,14 +4,14 @@ target TypeScript {
     fast: false,
     timeout: 3 sec
 };
-reactor foo {
+reactor Foo {
     input x:number;
     output y:number;
     reaction(x) -> y {=
         y = 2 * (x as number);
     =}
 }
-reactor print {
+reactor Print {
     state expected_time:time(10 msec);
     input x:number;
     reaction(x) {=
@@ -26,9 +26,9 @@ reactor print {
         expected_time = expected_time.add(new UnitBasedTimeValue(1, TimeUnit.sec));
     =}
 }
-main reactor top {
-    f = new foo();
-    p = new print();
+main reactor Top {
+    f = new Foo();
+    p = new Print();
     timer t(0, 1 sec);
     reaction(t) -> f.x {=
         f.x = 42;

--- a/test/test-manifest
+++ b/test/test-manifest
@@ -41,6 +41,7 @@ DoubleReaction.lf
 DoubleReactionThreaded.lf
 Gain.lf
 GainThreaded.lf
+GenericDelay.lf
 GetTime.lf
 Hello.lf
 HelloDistributed.lf

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/LinguaFrancaSynthesisUtilityExtensions.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/LinguaFrancaSynthesisUtilityExtensions.xtend
@@ -54,7 +54,7 @@ class LinguaFrancaSynthesisUtilityExtensions extends AbstractSynthesisExtensions
 	 * Trims the hostcode of reactions.
 	 */
 	def trimCode(Code tokenizedCode) {
-		if (tokenizedCode === null || tokenizedCode.tokens.nullOrEmpty) {
+		if (tokenizedCode === null || tokenizedCode.body.nullOrEmpty) {
 			return ""
 		}
 		try {
@@ -108,7 +108,7 @@ class LinguaFrancaSynthesisUtilityExtensions extends AbstractSynthesisExtensions
 			return lines.join("\n")
 		} catch(Exception e) {
 			e.printStackTrace
-			return tokenizedCode.tokens.join().replace(";",";\n") // just heuristic
+			return tokenizedCode.body
 		}
 	}
 	

--- a/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
+++ b/xtext/org.icyphy.linguafranca.diagram/src/org/icyphy/linguafranca/diagram/synthesis/styles/LinguaFrancaShapeExtensions.xtend
@@ -154,7 +154,7 @@ class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 		}
 
 		// optional code content
-		val hasCode = SHOW_REACTION_CODE.booleanValue && !reaction.code.tokens.nullOrEmpty
+		val hasCode = SHOW_REACTION_CODE.booleanValue && !reaction.code.body.nullOrEmpty
 		if (hasCode) {
 			contentContainer.addText(reaction.code.trimCode) => [
 				associateWith(reaction)
@@ -168,7 +168,7 @@ class LinguaFrancaShapeExtensions extends AbstractSynthesisExtensions {
 		}
 		
 		if (reaction.deadline !== null) {
-			val hasDeadlineCode = SHOW_REACTION_CODE.booleanValue && !reaction.deadline.code.tokens.nullOrEmpty
+			val hasDeadlineCode = SHOW_REACTION_CODE.booleanValue && !reaction.deadline.code.body.nullOrEmpty
 			if (hasCode || hasDeadlineCode) {
 				contentContainer.addHorizontalLine(0) => [
 					setGridPlacementData().from(LEFT, 5, 0, TOP, 3, 0).to(RIGHT, 5, 0, BOTTOM, 6, 0)

--- a/xtext/org.icyphy.linguafranca.tests/src/org/icyphy/tests/LinguaFrancaValidationTest.xtend
+++ b/xtext/org.icyphy.linguafranca.tests/src/org/icyphy/tests/LinguaFrancaValidationTest.xtend
@@ -40,6 +40,7 @@ import org.icyphy.linguaFranca.TimeUnit
 import org.icyphy.TimeValue
 import org.icyphy.Targets
 import org.icyphy.linguaFranca.Visibility
+import org.icyphy.generator.GeneratorBase
 
 @ExtendWith(InjectionExtension)
 @InjectWith(LinguaFrancaInjectorProvider)
@@ -135,7 +136,7 @@ class LinguaFrancaValidationTest {
         model_error_2.assertError(LinguaFrancaPackage::eINSTANCE.reactor, null,
             "Reactor cannot be named 'Preamble'")
     }
-    
+ 
     /**
      * Ensure that "__" is not allowed at the start of an input name.
      */

--- a/xtext/org.icyphy.linguafranca.tests/src/org/icyphy/tests/LinguaFrancaValidationTest.xtend
+++ b/xtext/org.icyphy.linguafranca.tests/src/org/icyphy/tests/LinguaFrancaValidationTest.xtend
@@ -31,16 +31,15 @@ import org.eclipse.xtext.testing.InjectWith
 import org.eclipse.xtext.testing.extensions.InjectionExtension
 import org.eclipse.xtext.testing.util.ParseHelper
 import org.eclipse.xtext.testing.validation.ValidationTestHelper
+import org.icyphy.Targets
+import org.icyphy.TimeValue
 import org.icyphy.linguaFranca.LinguaFrancaPackage
 import org.icyphy.linguaFranca.Model
+import org.icyphy.linguaFranca.TimeUnit
+import org.icyphy.linguaFranca.Visibility
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.^extension.ExtendWith
-import org.icyphy.linguaFranca.TimeUnit
-import org.icyphy.TimeValue
-import org.icyphy.Targets
-import org.icyphy.linguaFranca.Visibility
-import org.icyphy.generator.GeneratorBase
 
 @ExtendWith(InjectionExtension)
 @InjectWith(LinguaFrancaInjectorProvider)

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -27,13 +27,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.icyphy
 
-import java.util.HashMap
 import java.util.HashSet
 import java.util.LinkedList
 import java.util.List
 import java.util.Set
 import org.eclipse.emf.common.util.EList
-import org.eclipse.emf.ecore.resource.Resource
+import org.eclipse.xtext.nodemodel.ILeafNode
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.icyphy.generator.FederateInstance
 import org.icyphy.generator.GeneratorBase
 import org.icyphy.linguaFranca.Action
@@ -50,8 +50,10 @@ import org.icyphy.linguaFranca.StateVar
 import org.icyphy.linguaFranca.Time
 import org.icyphy.linguaFranca.TimeUnit
 import org.icyphy.linguaFranca.Type
-import org.icyphy.linguaFranca.TypeParm
 import org.icyphy.linguaFranca.Value
+import org.icyphy.linguaFranca.TypeParm
+import org.eclipse.emf.ecore.resource.Resource
+import java.util.HashMap
 
 /**
  * A helper class for modifying and analyzing the AST.
@@ -527,33 +529,28 @@ class ASTUtils {
      * @return Textual representation of the given argument.
      */
     def static String toText(Code code) {
-        if (code !== null && code.body !== null) {
-            return code.body.trimCodeBlock
-//            val node = NodeModelUtils.getNode(code)
-//            if (node !== null) {
-//                val builder = new StringBuilder(
-//                    Math.max(node.getTotalLength(), 1))
-//                for (ILeafNode leaf : node.getLeafNodes()) {
-//                    builder.append(leaf.getText());
-//                }
-//                var str = builder.toString.trim
-//                // remove the code delimiters
-//                str = str.substring(2, str.length - 2)
-//                if (str.split('\n').length > 1) {
-//                    // multi line code
-//                    return str.trimCodeBlock
-//                } else {
-//                    // single line code
-//                    return str.trim
-//                }    
-//            } else {
-//                // Code must have been added as a simple string.
-//                val builder = new StringBuilder(Math.max(code.tokens.length, 1))
-//                for (token : code.tokens) {
-//                    builder.append(token)
-//                }
-//                return builder.toString
-//            }
+        if (code !== null) {
+            val node = NodeModelUtils.getNode(code)
+            if (node !== null) {
+                val builder = new StringBuilder(
+                    Math.max(node.getTotalLength(), 1))
+                for (ILeafNode leaf : node.getLeafNodes()) {
+                    builder.append(leaf.getText());
+                }
+                var str = builder.toString.trim
+                // remove the code delimiters
+                str = str.substring(2, str.length - 2)
+                if (str.split('\n').length > 1) {
+                    // multi line code
+                    return str.trimCodeBlock
+                } else {
+                    // single line code
+                    return str.trim
+                }    
+            } else if (code.body !== null) {
+                // Code must have been added as a simple string.
+                return code.body.toString
+            }
         }
         return ""
     }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -27,13 +27,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.icyphy
 
+import java.util.HashMap
 import java.util.HashSet
 import java.util.LinkedList
 import java.util.List
 import java.util.Set
 import org.eclipse.emf.common.util.EList
-import org.eclipse.xtext.nodemodel.ILeafNode
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils
+import org.eclipse.emf.ecore.resource.Resource
 import org.icyphy.generator.FederateInstance
 import org.icyphy.generator.GeneratorBase
 import org.icyphy.linguaFranca.Action
@@ -50,10 +50,8 @@ import org.icyphy.linguaFranca.StateVar
 import org.icyphy.linguaFranca.Time
 import org.icyphy.linguaFranca.TimeUnit
 import org.icyphy.linguaFranca.Type
-import org.icyphy.linguaFranca.Value
 import org.icyphy.linguaFranca.TypeParm
-import org.eclipse.emf.ecore.resource.Resource
-import java.util.HashMap
+import org.icyphy.linguaFranca.Value
 
 /**
  * A helper class for modifying and analyzing the AST.
@@ -286,13 +284,13 @@ class ASTUtils {
         r1.triggers.add(inRef)
         r1.effects.add(effectRef)
         r1.code = factory.createCode()
-        r1.code.tokens.add(generator.generateDelayBody(action, inRef))
+        r1.code.body = generator.generateDelayBody(action, inRef)
     
         // Configure the second reaction.
         r2.triggers.add(triggerRef)
         r2.effects.add(outRef)
         r2.code = factory.createCode()
-        r2.code.tokens.add(generator.generateForwardBody(action, outRef))    
+        r2.code.body = generator.generateForwardBody(action, outRef)    
     
         // Add the reactions to the newly created reactor class.
         // These need to go in the opposite order in case
@@ -386,20 +384,20 @@ class ASTUtils {
         r1.triggers.add(inRef)
         r1.effects.add(effectRef)
         r1.code = factory.createCode()
-        r1.code.tokens.add(generator.generateNetworkSenderBody(
+        r1.code.body = generator.generateNetworkSenderBody(
             inRef,
             outRef,
             receivingPortID,
             leftFederate,
             rightFederate,
             action.inferredType
-        ))
+        )
 
         // Configure the receiving reaction.
         r2.triggers.add(triggerRef)
         r2.effects.add(outRef)
         r2.code = factory.createCode()
-        r2.code.tokens.add(generator.generateNetworkReceiverBody(
+        r2.code.body = generator.generateNetworkReceiverBody(
             action,
             inRef,
             outRef,
@@ -407,7 +405,7 @@ class ASTUtils {
             leftFederate,
             rightFederate,
             action.inferredType
-        ))
+        )
 
         // Add the reactions to the parent.
         parent.reactions.add(r1)
@@ -467,7 +465,7 @@ class ASTUtils {
             }
             if (original.code !== null) {
                 clone.code = factory.createCode
-                original.code.tokens.forEach[clone.code.tokens.add(it)]
+                clone.code.body = original.code.body
             }
             return clone
         }
@@ -484,7 +482,7 @@ class ASTUtils {
             clone.literal = original.literal
         } else if (original.code !== null) {
                 clone.code = factory.createCode
-                original.code.tokens.forEach[clone.code.tokens.add(it)]
+                clone.code.body = original.code.body
         }
         return clone
     }
@@ -502,7 +500,7 @@ class ASTUtils {
             // Set the type based on the argument type.
             if (original.code !== null) {
                 clone.code = factory.createCode
-                original.code.tokens?.forEach[clone.code.tokens.add(it)]
+                clone.code.body = original.code.body
             } 
             if (original.stars !== null) {
                 original.stars?.forEach[clone.stars.add(it)]
@@ -530,31 +528,32 @@ class ASTUtils {
      */
     def static String toText(Code code) {
         if (code !== null) {
-            val node = NodeModelUtils.getNode(code)
-            if (node !== null) {
-                val builder = new StringBuilder(
-                    Math.max(node.getTotalLength(), 1))
-                for (ILeafNode leaf : node.getLeafNodes()) {
-                    builder.append(leaf.getText());
-                }
-                var str = builder.toString.trim
-                // remove the code delimiters
-                str = str.substring(2, str.length - 2)
-                if (str.split('\n').length > 1) {
-                    // multi line code
-                    return str.trimCodeBlock
-                } else {
-                    // single line code
-                    return str.trim
-                }    
-            } else {
-                // Code must have been added as a simple string.
-                val builder = new StringBuilder(Math.max(code.tokens.length, 1))
-                for (token : code.tokens) {
-                    builder.append(token)
-                }
-                return builder.toString
-            }
+            return code.body.trimCodeBlock
+//            val node = NodeModelUtils.getNode(code)
+//            if (node !== null) {
+//                val builder = new StringBuilder(
+//                    Math.max(node.getTotalLength(), 1))
+//                for (ILeafNode leaf : node.getLeafNodes()) {
+//                    builder.append(leaf.getText());
+//                }
+//                var str = builder.toString.trim
+//                // remove the code delimiters
+//                str = str.substring(2, str.length - 2)
+//                if (str.split('\n').length > 1) {
+//                    // multi line code
+//                    return str.trimCodeBlock
+//                } else {
+//                    // single line code
+//                    return str.trim
+//                }    
+//            } else {
+//                // Code must have been added as a simple string.
+//                val builder = new StringBuilder(Math.max(code.tokens.length, 1))
+//                for (token : code.tokens) {
+//                    builder.append(token)
+//                }
+//                return builder.toString
+//            }
         }
         return ""
     }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -205,7 +205,7 @@ class ASTUtils {
         // Add a type parameter if the target supports it.
         if (generator.supportsGenerics) {
             val parm = factory.createTypeParm
-            parm.literal = "T extends Present"
+            parm.literal = generator.generateDelayGeneric()
             delayClass.typeParms.add(parm)
         }
         

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -118,7 +118,7 @@ class ASTUtils {
         val className = 
             generator.supportsGenerics ? 
                 GeneratorBase.GEN_DELAY_CLASS_NAME : 
-            '''«GeneratorBase.GEN_DELAY_CLASS_NAME»_«InferredType.fromAST(type).toText.hashCode.toString»'''
+            '''«GeneratorBase.GEN_DELAY_CLASS_NAME»_«Integer.toHexString(InferredType.fromAST(type).toText.hashCode)»'''
         // Only add class definition if it is not already there.
         val classDef = generatedClasses.findFirst[it | it.name.equals(className)]
         if (classDef !== null) {
@@ -146,15 +146,21 @@ class ASTUtils {
         action.name = "delay"
         action.minDelay = factory.createValue
         action.minDelay.parameter = delayParameter
-            
+        action.origin = ActionOrigin.LOGICAL
+                
         if (generator.supportsGenerics) {
             action.type = factory.createType
             action.type.id = "T"
         } else {
             action.type = type.copy
         }
-            
-        action.origin = ActionOrigin.LOGICAL
+        
+        input.name = "inp"
+        input.type = action.type.copy
+        
+        output.name = "out"
+        output.type = action.type.copy
+        
 
         // Establish references to the involved ports.
         inRef.variable = input
@@ -165,7 +171,7 @@ class ASTUtils {
         effectRef.variable = action
         
         // Add the action to the reactor.
-        delayClass.name = GeneratorBase.GEN_DELAY_CLASS_NAME 
+        delayClass.name = className
         delayClass.actions.add(action)
 
         // Configure the first reaction.
@@ -192,10 +198,12 @@ class ASTUtils {
         if (generator.supportsGenerics) {
             delayClass.typeParms.add("T")
         }
-        delayClass.actions.add(action)
+        
         delayClass.inputs.add(input)
         delayClass.outputs.add(output)
         delayClass.parameters.add(delayParameter)
+        
+        generatedClasses.add(delayClass)
         
         return delayClass
     }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -985,4 +985,13 @@ class ASTUtils {
         }
         return InferredType.undefined
     }
+
+    /**
+     * Check if the reactor class uses generics
+     * @param r the reactor to check 
+     * @true true if the reactor uses generics
+     */
+    def static isGeneric(Reactor r) {
+        return r.typeParms.length != 0;
+    }
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/ASTUtils.xtend
@@ -527,7 +527,7 @@ class ASTUtils {
      * @return Textual representation of the given argument.
      */
     def static String toText(Code code) {
-        if (code !== null) {
+        if (code !== null && code.body !== null) {
             return code.body.trimCodeBlock
 //            val node = NodeModelUtils.getNode(code)
 //            if (node !== null) {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
@@ -344,7 +344,8 @@ SignedFloat:
 // Just escaping with \ is not a good idea because then every \ has to be escaped \\.
 // Perhaps the string EQUALS_BRACE could become '=}'?
 Code:
-    {Code} '{=' (tokens+=Token)* '=}'
+    //{Code} '{=' (tokens+=Token)* '=}'
+    {Code} '{=' body=Body '=}'
 ;
 
 // The following cannot be terminal because it overlaps ID.
@@ -368,6 +369,10 @@ enum TimeUnit:
     HOUR='hour' | HOURS='hours' |
     DAY='day' | DAYS='days' |
     WEEK='week' | WEEKS='weeks';
+
+Body:
+    Token*
+;
 
 Token:
     // Imported terminals

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
@@ -121,10 +121,10 @@ Target:
 ;
 
 Input:
-    (mutable?='mutable'? & multiplex?='multiplex'?) 'input' (arraySpec=ArraySpec)? name=ID (':' type=Type)? ';';
+    mutable?='mutable'? 'input' (arraySpec=ArraySpec)? name=ID (':' type=Type)? ';';
 
 Output:
-    (multiplex?='multiplex')? 'output' (arraySpec=ArraySpec)? name=ID (':' type=Type)? ';';
+    'output' (arraySpec=ArraySpec)? name=ID (':' type=Type)? ';';
 
 // Timing specification for a timer: (offset, period)
 // Can be empty, which means (0,0) = (NOW, ONCE).
@@ -376,7 +376,7 @@ Token:
     'target' | 'import' | 'main' | 'realtime' | 'reactor' | 'state' | 'time' | 
     'mutable' | 'input' | 'output' | 'timer' | 'action' | 'reaction' | 
     'startup' | 'shutdown' | 'after' | 'deadline' | 'mutation' | 'preamble' |
-    'new' | 'federated' | 'at' | 'multiplex' |
+    'new' | 'federated' | 'at' |
     // Other terminals
     NEGINT | TRUE | FALSE |
     // Action origins

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/LinguaFranca.xtext
@@ -61,7 +61,7 @@ Import:
  */
 Reactor:
     ((federated?='federated' | main?='main')? & realtime?='realtime'?) 'reactor' name=ID 
-    ('<' typeParms+=ID (',' typeParms+=ID)* '>')?
+    ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')?
     ('(' parameters+=Parameter (',' parameters+=Parameter)* ')')?
     ('at' host=Host)?
     '{'
@@ -76,6 +76,16 @@ Reactor:
         | (reactions+=Reaction)
         | (mutations+=Mutation)
     )* '}';
+
+
+TypeParm:
+    literal=TypeExpr | code=Code
+;
+
+// Allows simple statements like "A extends B". We probably want to further expand this.
+TypeExpr:
+    ID+
+;
 
 /**
  * Specification of the target language. Target properties can be specified in
@@ -174,7 +184,7 @@ Preamble:
 
 Instantiation:
     name=ID '=' 'new' (arraySpec=ArraySpec)?
-    reactorClass=[Reactor] '(' 
+    reactorClass=[Reactor] ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? '(' 
     (parameters+=Assignment (',' parameters+=Assignment)*)? 
     ')' ('at' host=Host)? ';';
 
@@ -243,7 +253,7 @@ Port:
     
 // A type is in the target language, hence either an ID or target code.
 Type:
-   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) (stars+='*')* (arraySpec=ArraySpec | parameters=Generic)?) | code=Code);
+   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) (stars+='*')* ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? (arraySpec=ArraySpec)?) | code=Code);
 
 ArraySpec:
     ofVariableLength?='[]' | '[' length=INT ']';

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2952,4 +2952,8 @@ class CGenerator extends GeneratorBase {
         return false
     }
     
+    override generateDelayGeneric() {
+        throw new UnsupportedOperationException("TODO: auto-generated method stub")
+    }
+    
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2935,7 +2935,7 @@ class CGenerator extends GeneratorBase {
     override getTargetFixedSizeListType(String baseType,
         Integer size) '''«baseType»[«size»]'''
         
-    override protected String getTargetVariableSizeListType(
+    override String getTargetVariableSizeListType(
         String baseType) '''«baseType»[]'''
     
     protected def String getInitializer(ParameterInstance p) {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2096,7 +2096,7 @@ class CGenerator extends GeneratorBase {
             if («ref»_is_present) {
                 // Put the whole token on the event queue, not just the payload.
                 // This way, the length and element_size are transported.
-                schedule_token(«action.name», 0, «ref»);
+                schedule_token(«action.name», 0, «ref»_token);
             }
             '''
         } else {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2946,5 +2946,10 @@ class CGenerator extends GeneratorBase {
             	return p.init.get(0).targetValue
             }
         
-    }    
+    }
+    
+    override supportsGenerics() {
+        return false
+    }
+    
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -1036,5 +1036,8 @@ class CppGenerator extends GeneratorBase {
     override supportsGenerics() {
         true
     }
-        
+    
+    override String generateDelayGeneric()
+        '''T'''
+    
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -594,6 +594,7 @@ class CppGenerator extends GeneratorBase {
         «r.includeInstances»
         «r.publicPreamble»
         
+        «IF r.isGeneric»«r.templateLine»«ENDIF»
         class «r.name» : public reactor::Reactor {
          private:
           «r.declareParameters»
@@ -610,6 +611,10 @@ class CppGenerator extends GeneratorBase {
           
           void assemble() override;
         };
+    '''
+
+    def templateLine(Reactor r) '''
+        template<«FOR t: r.typeParms SEPARATOR ", "»class «t.toText»«ENDFOR»>
     '''
 
     def generate(Connection c) {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -286,6 +286,8 @@ class CppGenerator extends GeneratorBase {
         «FOR n : r.reactions SEPARATOR '\n'»
             «IF r.isGeneric»«r.templateLine»«ENDIF»
             void «r.templateName»::«n.name»_body() {
+              using namespace std::chrono_literals;
+              using namespace reactor::operators;
               «n.code.toText»
             }
         «ENDFOR»
@@ -295,6 +297,8 @@ class CppGenerator extends GeneratorBase {
         «FOR n : r.reactions.filter([Reaction x | x.deadline !== null]) BEFORE '\n' SEPARATOR '\n'»
             «IF r.isGeneric»«r.templateLine»«ENDIF»
             void «r.templateName»::«n.name»_deadline_handler() {
+              using namespace std::chrono_literals;
+              using namespace reactor::operators;
               «n.deadline.code.toText»
             }
         «ENDFOR»
@@ -678,9 +682,6 @@ class CppGenerator extends GeneratorBase {
         
         «IF !r.isGeneric»
         #include "reactor-cpp/reactor-cpp.hh"
-        
-        using namespace std::chrono_literals;
-        using namespace reactor::operators;
         
         #include "«r.headerFile»"
         «ENDIF»

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -286,8 +286,6 @@ class CppGenerator extends GeneratorBase {
         «FOR n : r.reactions SEPARATOR '\n'»
             «IF r.isGeneric»«r.templateLine»«ENDIF»
             void «r.templateName»::«n.name»_body() {
-              using namespace std::chrono_literals;
-              using namespace reactor::operators;
               «n.code.toText»
             }
         «ENDFOR»
@@ -297,8 +295,6 @@ class CppGenerator extends GeneratorBase {
         «FOR n : r.reactions.filter([Reaction x | x.deadline !== null]) BEFORE '\n' SEPARATOR '\n'»
             «IF r.isGeneric»«r.templateLine»«ENDIF»
             void «r.templateName»::«n.name»_deadline_handler() {
-              using namespace std::chrono_literals;
-              using namespace reactor::operators;
               «n.deadline.code.toText»
             }
         «ENDFOR»
@@ -686,6 +682,9 @@ class CppGenerator extends GeneratorBase {
         #include "«r.headerFile»"
         «ENDIF»
         #include "lfutil.hh"
+        
+        using namespace std::chrono_literals;
+        using namespace reactor::operators;
         
         «r.privatePreamble»
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -683,8 +683,8 @@ class CppGenerator extends GeneratorBase {
         using namespace reactor::operators;
         
         #include "«r.headerFile»"
-        #include "lfutil.hh"
         «ENDIF»
+        #include "lfutil.hh"
         
         «r.privatePreamble»
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -675,21 +675,19 @@ class CppGenerator extends GeneratorBase {
 
     def generateReactorSource(Reactor r) '''
         «r.eResource.header»
-        
-        «IF !r.isGeneric»
-        #include "reactor-cpp/reactor-cpp.hh"
-        
-        #include "«r.headerFile»"
-        «ENDIF»
-        #include "lfutil.hh"
-        
+
+        «IF !r.isGeneric»#include "reactor-cpp/reactor-cpp.hh"«ENDIF»
+
         using namespace std::chrono_literals;
         using namespace reactor::operators;
-        
+
+        «IF !r.isGeneric»#include "«r.headerFile»"«ENDIF»
+        #include "lfutil.hh"
+
         «r.privatePreamble»
 
         «r.defineConstructor»
-        
+
         «r.defineAssembleMethod»
 
         «r.implementReactionBodies»

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -210,12 +210,16 @@ class CppGenerator extends GeneratorBase {
         «ENDFOR»
     '''
 
+    def templateInstance(Instantiation i) '''
+        «i.reactorClass.name»«IF i.reactorClass.isGeneric»<«FOR t : i.typeParms SEPARATOR ", "»«t.toText»«ENDFOR»>«ENDIF»
+    '''
+
     def declareInstances(Reactor r) '''
         «FOR i : r.instantiations BEFORE '// reactor instantiations\n' AFTER '\n'»
             «IF i.arraySpec !== null»
-                std::array<«i.reactorClass.name», «i.arraySpec.length»> «i.name»;
+                std::array<«i.templateInstance», «i.arraySpec.length»> «i.name»;
             «ELSE»
-                «i.reactorClass.name» «i.name»;
+                «i.templateInstance» «i.name»;
             «ENDIF»
         «ENDFOR»
     '''

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -1000,4 +1000,9 @@ class CppGenerator extends GeneratorBase {
 
     override getTargetVariableSizeListType(
         String baseType) '''std::vector<«baseType»>'''
+        
+    override supportsGenerics() {
+        true
+    }
+        
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -116,6 +116,10 @@ class CppGenerator extends GeneratorBase {
         r.eResource.toDir + File.separator + r.name + ".hh"
     }
 
+    def headerImplFile(Reactor r) {
+        r.eResource.toDir + File.separator + r.name + "_impl.hh"
+    }
+
     def sourceFile(Reactor r) {
         r.eResource.toDir + File.separator + r.name + ".cc"
     }
@@ -146,7 +150,8 @@ class CppGenerator extends GeneratorBase {
         for (r : reactors) {
             fsa.generateFile(filename + File.separator + r.headerFile,
                 r.generateReactorHeader)
-            fsa.generateFile(filename + File.separator + r.sourceFile,
+            val implFile = r.isGeneric ? r.headerImplFile : r.sourceFile
+            fsa.generateFile(filename + File.separator + implFile,
                 r.generateReactorSource)
         }
 
@@ -611,6 +616,10 @@ class CppGenerator extends GeneratorBase {
           
           void assemble() override;
         };
+        «IF r.isGeneric»
+        
+        #include "«r.headerImplFile»"
+        «ENDIF»
     '''
 
     def templateLine(Reactor r) '''

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -313,11 +313,16 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         analyzeFederates(resource)
 
         // Find connections, and see whether they have a delay associated with them.
-        // For those that do, reroute the connection via a delay reactor. The connection
-        // between the delay reactor's output and the destination of the original connection
-        // must be added after iterating to avoid concurrent modification problems.
+        // For those that do, reroute the connection via a delay reactor. 
+        insertGeneratedDelays()
+            
+    }
+    
+    def void insertGeneratedDelays() {
+        // FIXME: move most of this to ASTUtils because the static functions shouldn't be public
         
-        
+        // The resulting changes to the AST are performed _after_ iterating iterating 
+        // to avoid concurrent modification problems.
         val oldConnections = new LinkedList<Connection>()
         val newConnections = new HashMap<Reactor, List<Connection>>()
         val delayInstances = new HashMap<Reactor, List<Instantiation>>()
@@ -346,7 +351,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         newConnections.forEach[ reactor, connections | reactor.connections.addAll(connections)]
         delayClasses.forEach[ reactor | this.resource.contents.add(reactor)]
         delayInstances.forEach[ reactor, instantiations | instantiations.forEach[ instantiation | instantiation.name = reactor.getUniqueIdentifier("delay"); reactor.instantiations.add(instantiation)]]
-    
+        
     }
     
     /** Generate code from the Lingua Franca model contained by the
@@ -437,8 +442,11 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      */
     abstract def String generateForwardBody(Action action, VarRef port);
     
+    /**
+     * Generate code for the generic type to be used in the class definition
+     * of a generated delay reactor.
+     */
     abstract def String generateDelayGeneric();
-    
     
     /**
      * Generate code for referencing a port, action, or timer.
@@ -1405,6 +1413,10 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         return returnCode
     }
     
+    /**
+     * Return true if the target supports generics (i.e., parametric
+     * polymorphism), false otherwise.
+     */
     abstract def boolean supportsGenerics()
     
     abstract def String getTargetTimeType()

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -325,8 +325,11 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         for (connection : resource.allContents.toIterable.filter(Connection)) {
             if (connection.delay !== null) {
                 val parent = connection.eContainer as Reactor
-                val delayClass = getDelayClass((connection.rightPort.variable as Port).type, delayClasses, this)
-                val delayInstance = getDelayInstance(delayClass, connection.delay)
+                val type = (connection.rightPort.variable as Port).type
+                val delayClass = getDelayClass(type, delayClasses, this)
+                val generic = this.supportsGenerics? InferredType.fromAST(type).toText : ""
+                val delayInstance = getDelayInstance(delayClass, connection.delay, generic)
+                
                 var connections = newConnections.get(parent)
                 if (connection !== null) connections = new LinkedList()
                 connections.addAll(connection.rerouteViaDelay(delayInstance))
@@ -1409,7 +1412,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
 
     abstract def String getTargetVariableSizeListType(String baseType);
     
-    def String getTargetType(InferredType type) { // FIXME: what about asterisks?
+    def String getTargetType(InferredType type) {
         if (type.isUndefined) {
             return targetUndefinedType
         } else if (type.isTime) {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -437,6 +437,9 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      */
     abstract def String generateForwardBody(Action action, VarRef port);
     
+    abstract def String generateDelayGeneric();
+    
+    
     /**
      * Generate code for referencing a port, action, or timer.
      * @param reference The referenced variable.

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -98,7 +98,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         TimeUnit.DAY -> 86400000000000L, TimeUnit.DAYS -> 86400000000000L,
         TimeUnit.WEEK -> 604800000000000L, TimeUnit.WEEKS -> 604800000000000L}
     
-    public static var GEN_DELAY_CLASS_NAME = "__GeneratedDelay"
+    public static var GEN_DELAY_CLASS_NAME = "__GenDelay"
     
     static protected CharSequence listItemSeparator = ', '
     
@@ -332,7 +332,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
                 connections.addAll(connection.rerouteViaDelay(delayInstance))
                 newConnections.put(parent, connections)
                 oldConnections.add(connection)
-                delayClasses.add(delayClass)
+                
                 var instances = (delayInstances.get(parent)?: emptyList)
                 if (instances !== null) instances = new LinkedList()
                 instances.addAll(delayInstance)
@@ -342,7 +342,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         oldConnections.forEach[ connection | (connection.eContainer as Reactor).connections.remove(connection)]
         newConnections.forEach[ reactor, connections | reactor.connections.addAll(connections)]
         delayClasses.forEach[ reactor | this.resource.contents.add(reactor)]
-        delayInstances.forEach[ reactor, instantiations | instantiations.forEach[ instantiation | instantiation.name = reactor.getUniqueIdentifier("delay")]; reactor.instantiations.addAll(instantiations)]
+        delayInstances.forEach[ reactor, instantiations | instantiations.forEach[ instantiation | instantiation.name = reactor.getUniqueIdentifier("delay"); reactor.instantiations.add(instantiation)]]
     
     }
     
@@ -1401,15 +1401,15 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
     
     abstract def boolean supportsGenerics()
     
-    abstract public def String getTargetTimeType()
+    abstract def String getTargetTimeType()
 
-    abstract public def String getTargetUndefinedType()
+    abstract def String getTargetUndefinedType()
     
-    abstract public def String getTargetFixedSizeListType(String baseType, Integer size)
+    abstract def String getTargetFixedSizeListType(String baseType, Integer size)
 
-    abstract public def String getTargetVariableSizeListType(String baseType);
+    abstract def String getTargetVariableSizeListType(String baseType);
     
-    protected def String getTargetType(InferredType type) {
+    def String getTargetType(InferredType type) { // FIXME: what about asterisks?
         if (type.isUndefined) {
             return targetUndefinedType
         } else if (type.isTime) {

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/LinguaFrancaGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/LinguaFrancaGenerator.xtend
@@ -44,9 +44,11 @@ class LinguaFrancaGenerator extends AbstractGenerator {
 
 	override void doGenerate(Resource resource, IFileSystemAccess2 fsa, IGeneratorContext context) {
 		// Determine which target is desired.
+		
+		var GeneratorBase generator
+		
 		for (target : resource.allContents.toIterable.filter(Target)) {
 		    
-		    var GeneratorBase generator
 			val t = Targets.get(target.name)
 			if (t === null) {
 			    System.err.println("Warning: Unrecognized target.")
@@ -63,10 +65,9 @@ class LinguaFrancaGenerator extends AbstractGenerator {
                     generator = new TypeScriptGenerator()
                 }
 			}
-			
-            generator.doGenerate(resource, fsa, context)
-            generatorErrorsOccurred = generator.errorsOccurred()
 		}
+		generator.doGenerate(resource, fsa, context)
+        generatorErrorsOccurred = generator.errorsOccurred()
 	}
 	
 	/** Return true if errors occurred in the last call to doGenerate().

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -263,11 +263,14 @@ class TypeScriptGenerator extends GeneratorBase {
             pr(p.code.toText)
             pr("\n// *********** End of preamble.")
         }
-
+        
+        val reactorName = reactor.name + reactor.typeParms?.join('<', ',', '>', [it.toText])
+        // NOTE: type parameters that are referenced in ports or actions must extend
+        // Present in order for the program to type check.
         if(reactor.isMain()){
-            pr("export class " + reactor.name + " extends App {")
+            pr("export class " + reactorName + " extends App {")
         } else {
-            pr("export class " + reactor.name + " extends Reactor {")
+            pr("export class " + reactorName + " extends Reactor {")
         }
         
         indent()
@@ -310,7 +313,7 @@ class TypeScriptGenerator extends GeneratorBase {
         
         // Next handle child reactors instantiations
         for (childReactor : reactor.instantiations ) {
-            pr(childReactor.getName() + ": " + childReactor.reactorClass.name )
+            pr(childReactor.getName() + ": " + childReactor.reactorClass.name + childReactor.typeParms.join('<', ',', '>', [it | it.toText]))
             
             var childReactorArguments = new StringJoiner(", ");
             childReactorArguments.add("this")
@@ -323,10 +326,9 @@ class TypeScriptGenerator extends GeneratorBase {
                 childReactorArguments.add(parameter.getTargetInitializer(childReactor))
             }
             
-            
             pr(reactorConstructor, "this." + childReactor.getName()
-                + " = new " + childReactor.reactorClass.name + "("
-                + childReactorArguments + ")" )
+                + " = new " + childReactor.reactorClass.name + 
+                "(" + childReactorArguments + ")" )
         }
        
         

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -1211,5 +1211,8 @@ import {ProcessedCommandLineArgs, CommandLineOptionDefs, CommandLineUsageDefs, C
     override supportsGenerics() {
         true
     }
+    
+    override String generateDelayGeneric()
+        '''T extends Present'''
 
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -1205,5 +1205,9 @@ import {ProcessedCommandLineArgs, CommandLineOptionDefs, CommandLineUsageDefs, C
     override protected String getTargetVariableSizeListType(String baseType) {
         '''Array<«baseType»>'''
     }
+    
+    override supportsGenerics() {
+        true
+    }
 
 }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -1190,19 +1190,19 @@ import {ProcessedCommandLineArgs, CommandLineOptionDefs, CommandLineUsageDefs, C
 
 '''
         
-    override protected String getTargetTimeType() {
+    override String getTargetTimeType() {
         "TimeValue"
     }
     
-    override protected String getTargetUndefinedType() {
+    override String getTargetUndefinedType() {
         "unknown"
     }
     
-    override protected String getTargetFixedSizeListType(String baseType, Integer size) {
+    override String getTargetFixedSizeListType(String baseType, Integer size) {
         '''Array(«size»)<«baseType»>'''
     }
     
-    override protected String getTargetVariableSizeListType(String baseType) {
+    override String getTargetVariableSizeListType(String baseType) {
         '''Array<«baseType»>'''
     }
     

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/validation/LinguaFrancaValidator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/validation/LinguaFrancaValidator.xtend
@@ -92,15 +92,14 @@ class LinguaFrancaValidator extends AbstractLinguaFrancaValidator {
      */
     static val ipv4Regex = "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}" +
                                 "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])"
-    // ((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])
+
     /**
      * Regular expression to check the validity of IPV6 addresses (due to David M. Syzdek),
      * with minor adjustment to allow up to six IPV6 segments (without truncation) in front
      * of an embedded IPv4-address. 
      **/
     static val ipv6Regex = 
-             
-               "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|" +
+                "(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|" +
                 "([0-9a-fA-F]{1,4}:){1,7}:|" + 
                 "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|" +
                 "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|" + 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/validation/LinguaFrancaValidator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/validation/LinguaFrancaValidator.xtend
@@ -41,11 +41,15 @@ import org.icyphy.linguaFranca.ActionOrigin
 import org.icyphy.linguaFranca.Assignment
 import org.icyphy.linguaFranca.Connection
 import org.icyphy.linguaFranca.Deadline
+import org.icyphy.linguaFranca.Host
+import org.icyphy.linguaFranca.IPV4Host
+import org.icyphy.linguaFranca.IPV6Host
 import org.icyphy.linguaFranca.Input
 import org.icyphy.linguaFranca.Instantiation
 import org.icyphy.linguaFranca.KeyValuePair
 import org.icyphy.linguaFranca.LinguaFrancaPackage.Literals
 import org.icyphy.linguaFranca.Model
+import org.icyphy.linguaFranca.NamedHost
 import org.icyphy.linguaFranca.Output
 import org.icyphy.linguaFranca.Parameter
 import org.icyphy.linguaFranca.Preamble
@@ -60,10 +64,6 @@ import org.icyphy.linguaFranca.Value
 import org.icyphy.linguaFranca.Visibility
 
 import static extension org.icyphy.ASTUtils.*
-import org.icyphy.linguaFranca.IPV4Host
-import org.icyphy.linguaFranca.IPV6Host
-import org.icyphy.linguaFranca.Host
-import org.icyphy.linguaFranca.NamedHost
 
 /**
  * Custom validation checks for Lingua Franca programs.


### PR DESCRIPTION
- Addresses #154
- Removes `multiplex` keyword from grammar
- Progress toward better support of generics
- No longer storing tokenized target code in list