### PR TITLE
Added org.eclipse.core.jobs to the dependencies to fix CGenerator

### DIFF
--- a/xtext/org.icyphy.linguafranca.tests/META-INF/MANIFEST.MF
+++ b/xtext/org.icyphy.linguafranca.tests/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.icyphy.linguafranca,
  org.eclipse.xtext.testing,
  org.eclipse.xtext.xbase.testing,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
- javax.annotation;bundle-version="1.2.0"
+ javax.annotation;bundle-version="1.2.0",
+ org.eclipse.core.jobs
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.icyphy.tests;x-internal=true


### PR DESCRIPTION
Running the  LinguaFrancaDependencyAnalysisTest  "As JUnit Test" inside Eclipse was failing with

java.lang.NoClassDefFoundError: org/eclipse/core/runtime/jobs/ISchedulingRule

because CGenerator.java needs it.  The solution is to add org.eclipse.core.jobs to the dependencies of org.icyphy.linguafranca.tests/META-INF/MANIFEST.MF
