### PR TITLE
Added support for auto bin generation on Windows for the CGenerator

### DIFF
--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -3298,7 +3298,7 @@ class CGenerator extends GeneratorBase {
             if (eObject instanceof Code) {
                 offset += 1
             }
-            pr(output, "#line " + (node.getStartLine() + offset) + '"file:' + unixSourceFile + '"')
+            pr(output, "#line " + (node.getStartLine() + offset) + ' "file:' + unixSourceFile + '"')
         }
     }
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -307,7 +307,7 @@ class CGenerator extends GeneratorBase {
         
         for (file : files) {
             copyFileFromClassPath(
-                File.separator + "lib" + File.separator + "C" + File.separator + file,
+                "/" + "lib" + "/" + "C" + "/" + file,
                 srcGenPath + File.separator + file
             )
         }
@@ -2714,7 +2714,7 @@ class CGenerator extends GeneratorBase {
      */
     protected def compileCommand(String fileToCompile) {
         val cFilename = fileToCompile + ".c";            
-        val relativeSrcFilename = "src-gen" + File.separator + cFilename;
+        val relativeSrcFilename = "src-gen" + "/" + cFilename;
         val relativeBinFilename = "bin" + File.separator + fileToCompile;
 
         var compileCommand = newArrayList
@@ -3298,7 +3298,7 @@ class CGenerator extends GeneratorBase {
             if (eObject instanceof Code) {
                 offset += 1
             }
-            pr(output, "#line " + (node.getStartLine() + offset) + ' "file:' + sourceFile + '"')
+            pr(output, "#line " + (node.getStartLine() + offset) + '"file:' + unixSourceFile + '"')
         }
     }
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -152,6 +152,9 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      */
     protected var String sourceFile
     
+    /** The UNIX full path (needed to access internal Java resources on all platforms */
+    protected var String unixSourceFile
+    
     /** The set of unordered reactions. An unordered reaction is one
      *  that does not have any dependency on other reactions in the
      *  containing reactor, and where no other reaction in the containing
@@ -1667,6 +1670,7 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      *  directory, filename, mode, sourceFile.
      */
     private def analyzeResource(Resource resource) {
+    	unixSourceFile = resource.getURI().toString();
         sourceFile = resource.toPath;
         
         // Strip the filename of the extension.


### PR DESCRIPTION
Two issues had to be addressed:

The first issue is that LF uses gcc as the targetCompiler in the CGenerator. This is fine as long as MingW is installed on Windows (I'd suggest we add that in the Prerequisites). Nonetheless, gcc requires Unix-like paths, and the File.separator doesn't work in that case.

The second issue was copyFileFromClassPath, which treats the source (its first argument) as a resource, which in Java always requires Unix-like paths (i.e., with forward slashes ("/") - see https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html).