### PR TITLE
Refactor command execution and unify it across targets

### DIFF
--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2318,10 +2318,9 @@ class CGenerator extends GeneratorBase {
      */
      def processProtoFile(String filename) {
         val protoc = createCommand("protoc-c", #["--c_out=src-gen", filename])
-        if (protoc === null) {
+        if (protoc !== null) {
             return
         }
-
         val returnCode = protoc.execute()
         if (returnCode == 0) {
             val nameSansProto = filename.substring(0, filename.length - 6)
@@ -2330,6 +2329,8 @@ class CGenerator extends GeneratorBase {
 
             compileLibraries.add('-l')
             compileLibraries.add('protobuf-c')    
+        } else {
+            reportError("protoc-c returns error code " + returnCode)
         }
     }
     

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -671,6 +671,24 @@ class CGenerator extends GeneratorBase {
         refreshProject()
     }
     
+    /** Invoke the compiler on the generated code. */
+    protected def compileCode() {
+        // If there is more than one federate, compile each one.
+        var fileToCompile = filename // base file name.
+        for (federate : federates) {
+            // Empty string means no federates were defined, so we only
+            // compile one file.
+            if (!federate.isSingleton) {
+                fileToCompile = filename + '_' + federate.name
+            }
+            executeCommand(compileCCommand(fileToCompile, true), directory)
+        }
+        // Also compile the RTI files if there is more than one federate.
+        if (federates.length > 1) {
+            compileRTI()
+        }
+    }
+    
     /** Overwrite the generated code after compile with a
      * clean version.
      */

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2318,7 +2318,7 @@ class CGenerator extends GeneratorBase {
      */
      def processProtoFile(String filename) {
         val protoc = createCommand("protoc-c", #["--c_out=src-gen", filename])
-        if (protoc !== null) {
+        if (protoc === null) {
             return
         }
         val returnCode = protoc.executeCommand()

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -2321,7 +2321,7 @@ class CGenerator extends GeneratorBase {
         if (protoc !== null) {
             return
         }
-        val returnCode = protoc.execute()
+        val returnCode = protoc.executeCommand()
         if (returnCode == 0) {
             val nameSansProto = filename.substring(0, filename.length - 6)
             compileAdditionalSources.add("src-gen" + File.separator + nameSansProto +

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CGenerator.xtend
@@ -681,7 +681,7 @@ class CGenerator extends GeneratorBase {
             if (!federate.isSingleton) {
                 fileToCompile = filename + '_' + federate.name
             }
-            executeCommand(compileCCommand(fileToCompile, true), directory)
+            runCCompiler(directory, fileToCompile, true)
         }
         // Also compile the RTI files if there is more than one federate.
         if (federates.length > 1) {
@@ -2317,21 +2317,20 @@ class CGenerator extends GeneratorBase {
      * @param filename Name of the file to process.
      */
      def processProtoFile(String filename) {
-        val protocCommand = newArrayList
-        protocCommand.addAll("protoc-c", "--c_out=src-gen", filename)
-        if (executeCommand(protocCommand, directory) != 0) {
-            return reportError(
-                "Protocol buffer compiler failed." +
-                    "\nFor installation instructions, see: https://github.com/protobuf-c/protobuf-c." +
-                    "\nMake sure that your PATH variable includes the directory where protoc-c is installed," +
-                    "\ntypically /usr/local/bin. You can set PATH in ~/.bash_profile on Linux or Mac.")
+        val protoc = createCommand("protoc-c", #["--c_out=src-gen", filename])
+        if (protoc === null) {
+            return
         }
-        val nameSansProto = filename.substring(0, filename.length - 6)
-        compileAdditionalSources.add("src-gen" + File.separator + nameSansProto +
-            ".pb-c.c")
 
-        compileLibraries.add('-l')
-        compileLibraries.add('protobuf-c')
+        val returnCode = protoc.execute()
+        if (returnCode == 0) {
+            val nameSansProto = filename.substring(0, filename.length - 6)
+            compileAdditionalSources.add("src-gen" + File.separator + nameSansProto +
+                ".pb-c.c")
+
+            compileLibraries.add('-l')
+            compileLibraries.add('protobuf-c')    
+        }
     }
     
     /**

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -1028,12 +1028,12 @@ class CppGenerator extends GeneratorBase {
         }
         
         // run cmake
-        val cmakeReturnCode = cmakeBuilder.execute();
+        val cmakeReturnCode = cmakeBuilder.executeCommand();
 
         if (cmakeReturnCode == 0) {
             // If cmake succeeded, prepare and run make
             makeBuilder.directory(buildDir)
-            val makeReturnCode = makeBuilder.execute()
+            val makeReturnCode = makeBuilder.executeCommand()
 
             if (makeReturnCode == 0) {
                 println("SUCCESS (compiling generated C++ code)")

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CppGenerator.xtend
@@ -1025,31 +1025,26 @@ class CppGenerator extends GeneratorBase {
             return
         }
 
-        println("--- In directory: " + buildDir)
-        println("--- Running: " + cmakeBuilder.command.join(" "))
         cmakeBuilder.directory(buildDir)
-        var cmakeEnv = cmakeBuilder.environment();
         if (targetCompiler !== null) {
+            val cmakeEnv = cmakeBuilder.environment();
             cmakeEnv.put("CXX", targetCompiler);
         }
 
-        val cmakeReturnCode = cmakeBuilder.runSubprocess();
-        if (cmakeReturnCode != 0) {
-            reportError("cmake terminated with an error code!")
-        } else {
+        val cmakeReturnCode = cmakeBuilder.execute();       
+        if (cmakeReturnCode == 0) {
             // If cmake succeeded, run make.
-            println("--- In directory: " + buildDir)
-            println("--- Running: " + makeBuilder.command.join(" "))
             makeBuilder.directory(buildDir)
-            val makeReturnCode = makeBuilder.runSubprocess()
-
+            val makeReturnCode = makeBuilder.execute()
             if (makeReturnCode == 0) {
                 println("SUCCESS (compiling generated C++ code)")
                 println('''Generated source code is in «srcPath»''')
                 println('''Compiled binary is in «installPath»/bin/«filename»''')
             } else {
-                reportError("make terminated with an error code!")
+                reportError('''make failed with error code «makeReturnCode»''')
             }
+        } else {
+            reportError('''cmake failed with error code «cmakeReturnCode»''')
         }
     }
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -918,13 +918,13 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      * @return the commands return code
      */
     protected def executeCommand(ProcessBuilder cmd, OutputStream errStream, OutputStream outStream) {
-        println('''--- In directory: «cmd.directory»''')
+        println('''--- In directory: «cmd.directory.absolutePath»''')
         println('''--- Executing command: «cmd.command.join(" ")»''')
 
         var List<OutputStream> outStreams = newArrayList
         var List<OutputStream> errStreams = newArrayList
         outStreams.add(System.out)
-        outStreams.add(System.err)
+        errStreams.add(System.err)
         if (outStream !== null) { outStreams.add(outStream) } 
         if (errStream !== null) { errStreams.add(errStream) }
 

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -775,39 +775,28 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         fOut.close()
     }
     
-
-    /** Invoke the compiler on the generated code. */
-    def compileCode() {
-
-        // If there is more than one federate, compile each one.
-        var fileToCompile = filename // base file name.
-        for (federate : federates) {
-            // Empty string means no federates were defined, so we only
-            // compile one file.
-            if (!federate.isSingleton) {
-                fileToCompile = filename + '_' + federate.name
-            }
-            executeCommand(compileCommand(fileToCompile, true), directory)
-        }
-        // Also compile the RTI files if there is more than one federate.
-        if (federates.length > 1) {
-            compileRTI()
-        }
-    }
-    
-    /** Invoke the compiler on the generated RTI */
+    /** Invoke the C compiler on the generated RTI 
+     * 
+     * The C RTI is used across targets. Thus we need to be able to compile 
+     * it from GeneratorBase. 
+     */
     def compileRTI() {
         var fileToCompile = filename + '_RTI'
-        executeCommand(compileCommand(fileToCompile, false), directory)
+        executeCommand(compileCCommand(fileToCompile, false), directory)
     }
     
     /** Return a command to compile the specified C file.
+     * 
+     * This produces a C specific compile command. Since this command is
+     * used across targets to build the RTI, it needs to be available in
+     * GeneratorBase.
+     * 
      *  @param fileToCompile The C filename without the .c extension.
      *  @param doNotLinkIfNoMain If true, the compile command will have a
      *  `-c` flag when there is no main reactor. If false, the compile command
      *  will never have a `-c` flag.
      */
-    protected def compileCommand(String fileToCompile, boolean doNotLinkIfNoMain) {
+    protected def compileCCommand(String fileToCompile, boolean doNotLinkIfNoMain) {
         val cFilename = getTargetFileName(fileToCompile);            
         val relativeSrcFilename = "src-gen" + File.separator + cFilename;
         val relativeBinFilename = "bin" + File.separator + fileToCompile;

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -1013,7 +1013,9 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         val whichReturn = whichBuilder.start().waitFor()
         if (whichReturn == 0) {
             println("SUCCESS")
-            return new ProcessBuilder(#[cmd] + args)
+            val builder = new ProcessBuilder(#[cmd] + args)
+            builder.directory(new File(directory))
+            return builder
         }
         println("FAILED")
         // Try running with bash.

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -803,7 +803,6 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         }
 
         val stderr = new ByteArrayOutputStream()
-        compile.directory(new File(directory))
         val returnCode = compile.execute(stderr)
 
         if (returnCode != 0 && mode !== Mode.INTEGRATED) {
@@ -942,8 +941,8 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
      * @return 0 if the command succeeds, otherwise, an error code.
      */
     protected def executeCommand(ArrayList<String> command, String directory) {
-        println("In directory: " + directory)
-        println("Executing command: " + command.join(" "))
+        println("--- In directory: " + directory)
+        println("--- Executing command: " + command.join(" "))
         var builder = new ProcessBuilder(command);
         builder.directory(new File(directory));
         try {
@@ -1123,7 +1122,9 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         val bashReturn = bashBuilder.start().waitFor()
         if (bashReturn == 0) {
             println("SUCCESS")
-            return new ProcessBuilder(#["bash", "--login", "-c", '''«cmd» «args.join(" ")»'''])
+            val builder = new ProcessBuilder(#["bash", "--login", "-c", '''«cmd» «args.join(" ")»'''])
+            builder.directory(new File(directory))
+            return builder
         }
         println("FAILED")
         reportError("The command " + cmd + " could not be found.\n" +

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -832,8 +832,10 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         val relativeBinFilename = "bin" + File.separator + fileToCompile;
 
         var compileArgs = newArrayList
-        val flags = targetCompilerFlags.split(' ')
-        compileArgs.addAll(flags)
+        if (targetCompilerFlags !== null && !targetCompilerFlags.isEmpty()) {
+            val flags = targetCompilerFlags.split(' ')
+            compileArgs.addAll(flags)
+        }
         compileArgs.add(relativeSrcFilename)
         compileArgs.addAll(compileAdditionalSources)
         compileArgs.addAll(compileLibraries)

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -998,11 +998,11 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
     /**
      * Creates a ProcessBuilder for a given command and its arguments.
      * 
-     * This method ensures that the given command is executable,
-     * It first tries to find the command with 'which cmake'. If that
-     * fails, it tries again with bash. n case this fails again,
-     * it returns null. Otherwise, a correctly constructed ProcessBuilder
-     * object is returned. 
+     * This method ensures that the given command is executable. It first tries 
+     * to find the command with 'which <cmd>' (or 'where <cmd>' on Windows). If 
+     * that fails, it tries again with bash. In case this fails again, this
+     * method returns null. Otherwise, it returns correctly constructed 
+     * ProcessBuilder object. 
      * 
      * @param cmd The command to be executed
      * @param args A list of arguments for the given command
@@ -1011,7 +1011,9 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
     protected def createCommand(String cmd, List<String> args) {
         // Make sure the command is found in the PATH.
         print('''--- Looking for command «cmd» ... ''')
-        val whichBuilder = new ProcessBuilder(#["which", cmd])
+        // Use 'where' on Windows, 'which' on other systems
+        val which = System.getProperty("os.name").startsWith("Windows") ? "where" : "which"
+        val whichBuilder = new ProcessBuilder(#[which, cmd])
         val whichReturn = whichBuilder.start().waitFor()
         if (whichReturn == 0) {
             println("SUCCESS")

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/GeneratorBase.xtend
@@ -1028,10 +1028,14 @@ abstract class GeneratorBase extends AbstractLinguaFrancaValidator {
         print('''--- Trying again with bash ... ''')
         val bashCommand = #["bash", "--login", "-c", '''which «cmd»''']
         val bashBuilder = new ProcessBuilder(bashCommand)
-        val bashReturn = bashBuilder.start().waitFor()
+        val bashOut = new ByteArrayOutputStream()
+        val bashReturn = bashBuilder.runSubprocess(#[bashOut], #[])
         if (bashReturn == 0) {
             println("SUCCESS")
-            val builder = new ProcessBuilder(#["bash", "--login", "-c", '''«cmd» «args.join(" ")»'''])
+            // extract the full command from the output of which
+            val newCmd = bashOut.toString().trim()
+            // use that command to build the process
+            val builder = new ProcessBuilder(#[newCmd] + args)
             builder.directory(new File(directory))
             return builder
         }

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -241,7 +241,7 @@ class TypeScriptGenerator extends GeneratorBase {
         
         if (runNpmInstall) {
             val npmInstall = createCommand("npm", #["install"])
-            if (npmInstall !== null && npmInstall.execute() !== 0) {
+            if (npmInstall !== null && npmInstall.executeCommand() !== 0) {
                 reportError(resource.findTarget, "ERROR: npm install command failed."
                     + "\nFor installation instructions, see: https://www.npmjs.com/get-npm")
                 return
@@ -272,8 +272,7 @@ class TypeScriptGenerator extends GeneratorBase {
                 return
             }
 
-            protoc.directory(new File (directory))
-            val returnCode = protoc.execute()
+            val returnCode = protoc.executeCommand()
             if (returnCode == 0) {
                 val nameSansProto = filename.substring(0, filename.length - 6)
                 compileAdditionalSources.add("src-gen" + File.separator + nameSansProto +
@@ -309,14 +308,14 @@ class TypeScriptGenerator extends GeneratorBase {
         
         println("Type Checking")
         val tsc = createCommand("tsc")
-        if (tsc !== null && tsc.execute() == 0) {
+        if (tsc !== null && tsc.executeCommand() == 0) {
             // Babel will compile TypeScript to JS even if there are type errors
             // so only run compilation if tsc found no problems.
             val babelPath = directory + File.separator + "node_modules" + File.separator + ".bin" + File.separator + "babel"
             // Working command  $./node_modules/.bin/babel src-gen --out-dir js --extensions '.ts,.tsx'
             val babel = createCommand(babelPath, #["src", "--out-dir", "dist", "--extensions", ".ts", "--ignore", "**/*.d.ts"])
             println("Compiling")
-            if (babel !== null && babel.execute() == 0) {
+            if (babel !== null && babel.executeCommand() == 0) {
                 println("SUCCESS (compiling generated TypeScript code)")                
             } else {
                 reportError("Compiler failed.")

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -241,7 +241,7 @@ class TypeScriptGenerator extends GeneratorBase {
         
         if (runNpmInstall) {
             val npmInstall = createCommand("npm", #["install"])
-            if (npmInstall !== null && npmInstall.executeCommand() !== 0) {
+            if (npmInstall === null || npmInstall.executeCommand() !== 0) {
                 reportError(resource.findTarget, "ERROR: npm install command failed."
                     + "\nFor installation instructions, see: https://www.npmjs.com/get-npm")
                 return

--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/TypeScriptGenerator.xtend
@@ -301,13 +301,8 @@ class TypeScriptGenerator extends GeneratorBase {
         
         // FIXME: Perhaps add a compileCommand option to the target directive, as in C.
         // Here, we just use a generic compile command.
-        var typeCheckCommand = newArrayList()
-
-        // If $tsc is run with no arguments, it uses the tsconfig file.
-        typeCheckCommand.addAll(tscPath)
-        
         println("Type Checking")
-        val tsc = createCommand("tsc")
+        val tsc = createCommand(tscPath)
         if (tsc !== null && tsc.executeCommand() == 0) {
             // Babel will compile TypeScript to JS even if there are type errors
             // so only run compilation if tsc found no problems.


### PR DESCRIPTION
This change refactors the way we execute commands across targets. The old way we used in GeneratorBase had two major downsides:
1. It was not general enough to support the C++ target. For instance, it did not provide a mechanism for setting environment variables.
2. The retry mechanism used to get things to work on Mac OS was buggy (see #206) 

With this change, executing a command becomes a two-step process. First, `createComand(cmd, args)` is used to create a new `ProcessBuilder` object. `createCommand()` makes sure that the specified command is actually available by running `which cmd`. If it is not available, it tries again using the bash shell mechanism. In either case, it returns the proper `ProcessBuilder` object that can be modified as needed (e.g. set the directory or environment variables). Second, `executeCommand(builder)` executes the previously created command. The function can be given an optional parameter in order to record the command's outputs. This is important to process and report any errors as, for instance, the C target does.

Before we merge this, I think it is important to test this change on various platforms. Edward, could you test if this works on your 
Mac? Travis is currently doing his part, but I am not sure if these tests also cover RTI generation and proto buffers. If not, it should also be tested if the commands for these features work as expected.

closes #206 