### PR TITLE
bugfix: allow both relative and absolute paths to be passed to lfc

### DIFF
--- a/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/Main.xtend
+++ b/xtext/org.icyphy.linguafranca/src/org/icyphy/generator/Main.xtend
@@ -117,20 +117,17 @@ class Main {
     /**
      * Load resource, validate it, and, invoke the code generator.
      */
-    def protected runGenerator(String string, Properties properties) {
-        // Load the resource
-        val set = resourceSetProvider.get
-        val fileRoot = (new File("")).getAbsolutePath()
-        val fileName = fileRoot + File.separator + string;
-
-        val f = new File(fileName)
+    def protected runGenerator(String path, Properties properties) {
+        val f = new File(path)
         if (!f.exists) {
-            System::err.println('lfc: error: ' + fileName +
+            System::err.println('lfc: error: ' + path +
                 ': No such file or directory');
-            throw new FileNotFoundException(fileName);
+            throw new FileNotFoundException(path);
         }
 
-        val resource = set.getResource(URI.createFileURI(fileName), true)
+        // Load the resource
+        val set = resourceSetProvider.get
+        val resource = set.getResource(URI.createFileURI(f.absolutePath), true)
 
         // Validate the resource
         val issues = validator.validate(resource, CheckMode.ALL,


### PR DESCRIPTION
There is currently a bug in lfc that makes it impossible to provide an absolute path to a .lf file. This is because the code assumes that the path is relative and always adds the CWD as a prefix. This fix leverages the builtin file resolution mechanism of `File` instead and works with both relative and absolute paths.

I am not 100% sure that this works in all the possible cases and all platforms. Therefore, I open is PR to get some more eyes on the problem.