### PR TITLE
"trace" variable declared as extern since already in trace_util.c

### DIFF
--- a/util/tracing/trace_to_chrome.c
+++ b/util/tracing/trace_to_chrome.c
@@ -41,7 +41,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PID_FOR_UNKNOWN_EVENT 2000000
 
 /** Buffer for reading trace records. */
-trace_record_t trace[TRACE_BUFFER_CAPACITY];
+extern trace_record_t trace[TRACE_BUFFER_CAPACITY];
 
 /** Maximum thread ID seen. */
 int max_thread_id = 0;


### PR DESCRIPTION
"trace" variable declared as extern otherwise it does not compile at least on Linux with gcc 10.2.1:
`gcc -o trace_to_chrome trace_to_chrome.o trace_util.o
/usr/lib64/gcc/x86_64-suse-linux/10/../../../../x86_64-suse-linux/bin/ld: trace_util.o:(.bss+0x420): multiple definition of 'trace'; trace_to_chrome.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make: *** [makefile:17: trace_to_chrome] Error 1
`