### PR TITLE
trace variable removed since already declared in trace_util.c

### DIFF
--- a/util/tracing/trace_to_chrome.c
+++ b/util/tracing/trace_to_chrome.c
@@ -41,7 +41,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PID_FOR_UNKNOWN_EVENT 2000000
 
 /** Buffer for reading trace records. */
-trace_record_t trace[TRACE_BUFFER_CAPACITY];
+extern trace_record_t trace[TRACE_BUFFER_CAPACITY];
 
 /** Maximum thread ID seen. */
 int max_thread_id = 0;

--- a/util/tracing/trace_to_chrome.c
+++ b/util/tracing/trace_to_chrome.c
@@ -40,9 +40,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PID_FOR_WORKER_ADVANCING_TIME 0 // Use 1000002 to show in separate trace.
 #define PID_FOR_UNKNOWN_EVENT 2000000
 
-/** Buffer for reading trace records. */
-extern trace_record_t trace[TRACE_BUFFER_CAPACITY];
-
 /** Maximum thread ID seen. */
 int max_thread_id = 0;
 


### PR DESCRIPTION
remove the "trace" variable declared both in trace_to_chrome.c and trace_util.c, leading to linking failure.