### PR TITLE
Start at a set of design pattern examples

### DIFF
--- a/example/C/src/Patterns/Chain_01_SendReceive.lf
+++ b/example/C/src/Patterns/Chain_01_SendReceive.lf
@@ -1,0 +1,15 @@
+/**
+ * Very basic chain with just two reactors, one that sends
+ * a message a startup feeding one that reports receiving it.
+ * 
+ * @author Edward A. Lee
+ */
+target C;
+
+import SendOnce, Receive from "lib/SendersAndReceivers.lf";
+
+main reactor {
+    r1 = new SendOnce();
+    r2 = new Receive();
+    r1.out -> r2.in;
+}

--- a/example/C/src/Patterns/Chain_02_Pipeline.lf
+++ b/example/C/src/Patterns/Chain_02_Pipeline.lf
@@ -1,0 +1,37 @@
+/**
+ * Basic pipeline pattern where a periodic source feeds
+ * a chain of reactors that can all execute in parallel
+ * at each logical time step.
+ * 
+ * The threads argument specifies the number of worker
+ * threads, which enables the reactors in the chain to
+ * execute on multiple cores simultaneously.
+ * 
+ * This uses the TakeTime reactor to perform computation
+ * (it computes Fibonacci numbers). If you reduce the
+ * number of worker threads to 1, the execution time
+ * will be approximately four times as long.
+ * 
+ * @author Edward A. Lee
+ */
+target C {
+    threads: 4,
+    timeout: 1 sec
+}
+
+import SendCount, Receive from "lib/SendersAndReceivers.lf";
+import TakeTime from "lib/TakeTime.lf";
+
+main reactor {
+    r0 = new SendCount(period = 100 msec);
+    r1 = new TakeTime(approximate_time = 100 msec);
+    r2 = new TakeTime(approximate_time = 100 msec);
+    r3 = new TakeTime(approximate_time = 100 msec);
+    r4 = new TakeTime(approximate_time = 100 msec);
+    r5 = new Receive();
+    r0.out -> r1.in;
+    r1.out -> r2.in after 100 msec;
+    r2.out -> r3.in after 100 msec;
+    r3.out -> r4.in after 100 msec;
+    r4.out -> r5.in;
+}

--- a/example/C/src/Patterns/Loop_01_Single.lf
+++ b/example/C/src/Patterns/Loop_01_Single.lf
@@ -1,0 +1,20 @@
+/**
+ * A single reactor sends data to itself.
+ * The receiving reaction has to be appear lexically later
+ * in the source code, so that the sending reaction has
+ * higher priority, or else a causality loop arises.
+ * You can observe the causality loop by replacing the
+ * imported reactor with ReceiveAndSendPeriodically.
+ * 
+ * @author Edward A. Lee
+ */
+target C {
+    timeout: 5 sec
+};
+
+import SendPeriodicallyAndReceive from "lib/SendersAndReceivers.lf";
+
+main reactor {
+    r1 = new SendPeriodicallyAndReceive();
+    r1.out -> r1.in;
+}

--- a/example/C/src/Patterns/Loop_02_SingleDelay.lf
+++ b/example/C/src/Patterns/Loop_02_SingleDelay.lf
@@ -1,0 +1,24 @@
+/**
+ * A single reactor sends data to itself with delay.
+ * Unlike Loop_01_Single.lf, this can have reactions
+ * appear in reverse order, where the receiving reaction
+ * occurs before the sending reaction. This is because the
+ * delay of a single microstep breaks the causality loop.
+ * 
+ * Note that the received values are reported at microstep 1
+ * rather than 0.
+ * 
+ * @author Edward A. Lee
+ */
+target C {
+    timeout: 5 sec
+};
+
+import ReceiveAndSendPeriodically from "lib/SendersAndReceivers.lf";
+
+main reactor (
+    a_1_1:time(0) 
+) {
+    r1 = new ReceiveAndSendPeriodically();
+    r1.out -> r1.in after a_1_1;
+}

--- a/example/C/src/Patterns/README.md
+++ b/example/C/src/Patterns/README.md
@@ -1,0 +1,5 @@
+This directory contains Lingua Franca programs representing a number of common design patterns. The naming convention is that each example is in a file named Class_Num_Description.lf, where Class identifies a class of patterns (Chain, Loop, etc.), the Num is a two digit number suggesting the order in which to look at the examples, and Description is a short hint at what particular variant of the pattern the program represents.
+
+These programs reuse a collection of library reactors contained in the lib subdirectory.
+
+If you add to these patterns, please use or extend the library reactors rather than just creating new reactors with similar functionality. Please also fully document your patterns. What do they illustrate? How can the user experiment with them? Also, for each pattern, please add a test in the test subdirectory. Tests should use corresponding test receivers in the lib directory.

--- a/example/C/src/Patterns/lib/SendersAndReceivers.lf
+++ b/example/C/src/Patterns/lib/SendersAndReceivers.lf
@@ -1,0 +1,205 @@
+/**
+ * Library of reactors that are reused in various design pattern examples.
+ * 
+ * @author Edward A. Lee
+ */
+target C;
+
+/**
+ * Send an output (42) at startup.
+ */
+reactor SendOnce {
+    output out:int;
+    reaction(startup) -> out {=
+        SET(out, 42);
+    =}
+}
+
+/**
+ * Send counting sequence periodically.
+ * 
+ * @param offset The starting time.
+ * @param period The period.
+ * @param initial The first output.
+ * @param increment The increment between outputs
+ */
+reactor SendCount(
+    offset:time(0), 
+    period:time(1 sec),
+    initial:int(0),
+    increment:int(1)
+) {
+    state count:int(initial);
+    output out:int;
+    timer t(offset, period);
+    reaction(t) -> out {=
+        SET(out, self->count);
+        self->count += self->increment;
+    =}
+}
+
+/**
+ * Receive an input and report the elpased logical tag
+ * and the value of the input.
+ */
+reactor Receive {
+    input in:int;
+    reaction(in) {=
+        info_print("At elapsed tag (%lld, %d), received %d.",
+            get_elapsed_logical_time(), get_microstep(),
+            in->value
+        );
+    =}
+}
+
+reactor ReceiveAndSend {
+    input in:int;
+    output out:int;
+    reaction(in) -> out {=
+        SET(out, in->value);
+    =}
+}
+reactor SendOnceAndReceive {
+    input in:int;
+    output out:int;
+    reaction(startup) -> out {=
+        SET(out, 42);
+    =}
+    reaction(in) {=
+        info_print("At tag (%lld, %d), received %d.",
+            get_elapsed_logical_time(),
+            get_microstep(),
+            in->value
+        );
+    =}
+}
+
+/**
+ * This reactor periodically increments its state and sends it out.
+ * When an input is received, it simply reports the value.
+ * 
+ * @param offset The time of the first output.
+ * @param period The period of the outputs.
+ * @param initial The initial output value.
+ * @param increment The increment between outputs.
+ * 
+ * @input in The input to report.
+ * @output out The counting output.
+ * 
+ * @label Increment the state, send, report received.
+ */
+reactor SendPeriodicallyAndReceive extends SendCount, Receive {
+    // This reactor simply composes SendCount and Receive, in that order.
+}
+
+/**
+ * This reactor periodically increments its state and sends it out.
+ * When an input is received, it simply reports the value.
+ * 
+ * @param offset The time of the first output.
+ * @param period The period of the outputs.
+ * @param initial The initial output value.
+ * @param increment The increment between outputs.
+ * 
+ * @input in The input to report.
+ * @output out The counting output.
+ * 
+ * @label Increment the state, send, report received.
+ */
+reactor ReceiveAndSendPeriodically extends Receive, SendCount {
+    // This reactor simply composes Receive and SendCount, in that order.
+}
+
+/**
+ * This reactor periodically increments its state and sends it out.
+ * When an input is received, it simply reports the value.
+ * @label Increment the state, send, report received.
+ */
+reactor SendPeriodicallyAndReceiveMultiport (
+    offset:time(0),
+    period:time(1 sec),
+    initial:int(0),
+    increment:int(1),
+    width:int(4)
+) {
+    input[width] in:int;
+    output out:int;
+    
+    timer t(offset, period);
+    
+    state count:int(initial);
+    
+    reaction(t) -> out {=
+        SET(out, self->count);
+        self->count += self->increment;
+    =}
+    reaction(in) {=
+        info_print("At tag (%lld, %d), received:",
+            get_elapsed_logical_time(), get_microstep()
+        );
+        for (int i = 0; i < self->width; i++) {
+            info_print("  On channel %d: %d", i, in[i]->value);
+        }
+    =}
+}
+
+/**
+ * This reactor maintains a local state that periodically incremented
+ * and incremented whenever an input arrives.
+ * @label Increment the state, send increment, accept increment.
+ */
+reactor LocalRemoteUpdates(
+    offset:time(0),
+    period:time(1 sec),
+    increment:int(1)
+) {
+    input in:int;
+    output out:int;
+    
+    timer t(offset, period);
+    
+    state count:int(0);
+    
+    reaction(t) -> out {=
+        SET(out, self->increment);
+        self->count += self->increment;
+    =}
+    reaction(in) {=
+        self->count += in->value;
+        info_print("At tag (%lld, %d), count is %d",
+            get_elapsed_logical_time(), get_microstep(),
+            self->count
+        );
+    =}
+}
+// @label Accumulate local/remote increments, locally query.
+reactor SendAndReceiveWithLocalQuery(
+    query_offset:time(0),
+    query_period:time(1 sec)
+) extends LocalRemoteUpdates {
+    local_query = new SendPeriodicallyAndReceive(
+        offset = query_offset,
+        period = query_period
+    );
+    reaction(local_query.out) -> local_query.in {=
+        SET(local_query.in, self->count);
+    =}
+}
+// @label Accumulate local/remote increments, delayed query.
+reactor SendAndReceiveWithDelayedQuery(
+    query_offset:time(0),
+    query_period:time(1 sec),
+    query_delay:time(10 msec)
+) extends LocalRemoteUpdates {
+    local_query = new SendPeriodicallyAndReceive(
+        offset = query_offset,
+        period = query_period
+    );
+    logical action a(query_delay);
+    reaction(local_query.out) -> a {=
+        schedule(a, 0);
+    =}
+    reaction(a) -> local_query.in {=
+        SET(local_query.in, self->count);
+    =}
+}

--- a/example/C/src/Patterns/lib/TakeTime.lf
+++ b/example/C/src/Patterns/lib/TakeTime.lf
@@ -1,0 +1,44 @@
+target C;
+/**
+ * Compute Fibonacci numbers until at least the specified
+ * physical time has passed. This will compute numbers until
+ * they overflow the 64-bit representation, and then start over.
+ * When at least the specified physical time has elapased,
+ * report the last number computed.
+ * This is used in some design patterns to provide
+ * significant computation. 
+ * 
+ * @param approximate_time The approximate amount of physical 
+ *  time to take for each input.
+ * 
+ * @input in A triggering input.
+ * 
+ * @output out The computed Fibonacci number. 
+ */
+reactor TakeTime(
+    approximate_time:time(100 msec)
+) {
+    input in:int;
+    output out:int;
+    reaction(in) -> out {=
+        instant_t start_time = get_physical_time();
+        int f0 = 0;
+        int f1 = 1;
+        int count = 0;
+        while (get_physical_time() < start_time + self->approximate_time) {
+        	int next_term = f0 + f1;
+        	if (next_term < 0LL) {
+                // Overflow has occurred. Start over.
+                count = 0;
+                f0 = 0;
+                f1 = 1;
+            } else {
+            	f0 = f1;
+            	f1 = next_term;
+            	count++;
+            }
+        }
+        SET(out, f1);
+        info_print("The %d-th Fibonacci number is %d.", count, f0);
+    =}
+}


### PR DESCRIPTION
I have tuned up the pattern examples. Note that several of them do not display properly in the diagrams view, but I think that will be fixed when the diagram view is based on ReactorInstance rather than its own version of the instance graph.