### PR TITLE
LF filetype Vim plugin

### DIFF
--- a/util/lingua-franca.vim/ftdetect/linguafranca.vim
+++ b/util/lingua-franca.vim/ftdetect/linguafranca.vim
@@ -1,0 +1,3 @@
+" ftdetect/linguafranca.vim
+
+autocmd BufNewFile,BufRead *.lf setfiletype linguafranca

--- a/util/lingua-franca.vim/ftplugin/linguafranca.vim
+++ b/util/lingua-franca.vim/ftplugin/linguafranca.vim
@@ -1,0 +1,26 @@
+" ftplugin/linguafranca.vim
+" Arbitrary linguafranca related vim code
+
+setlocal commentstring=//%s
+setlocal formatoptions=jcroq
+" 'comments' configuration stolen from the C file, let's see how it works
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+
+" function! CursorInTargetBlock()
+"   " TODO
+"   " See: :help searchpair(), searchpairpos(), `n` flag
+" endfunction
+
+" function! LFTargetTextObject()
+"   " TODO
+"   if ! CursorInTargetBlock()
+"     return
+"   endif
+" endfunction
+
+" Text objects for the target blocks
+" Don't work very well but can be convenient
+onoremap <buffer> i= :<C-u>execute "normal! ?{=?e+1\rv/=}/b-1\r"<cr>
+xnoremap <buffer> i= :<C-u>execute "normal! ?{=?e+1\rv/=}/b-1\r"<cr>
+onoremap <buffer> a= :<C-u>execute "normal! ?{=\rv/=}/e\r"<cr>
+xnoremap <buffer> a= :<C-u>execute "normal! ?{=\rv/=}/e\r"<cr>

--- a/util/lingua-franca.vim/syntax/linguafranca.vim
+++ b/util/lingua-franca.vim/syntax/linguafranca.vim
@@ -1,0 +1,61 @@
+" syntax/linguafranca.vim
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+function! LFGetTarget()
+  " cf https://github.com/icyphy/lingua-franca/blob/0870cf86185733180d7b09f32fa5221a948af83b/org.lflang/src/org/lflang/LinguaFranca.xtext#L118
+  " and https://www.eclipse.org/Xtext/documentation/301_grammarlanguage.html#common-terminals
+  let l:pattern = '^\s*target\s*\(\h\h*\)\s*\({\|;\)\?\s*'
+  for l in getbufline("", 1, "$")
+    if l =~# l:pattern
+      let l:result = substitute(l, l:pattern, '\1', "")
+      break
+    endif
+  endfor
+
+  if exists("l:result")
+    return l:result
+  else
+    " TODO Handle error
+    return "Cpp"
+  endif
+endfunction
+
+function! LFGetSyntaxFile()
+  return "syntax/". tolower(LFGetTarget()). ".vim"
+endfunction
+
+" case sensitive
+syntax case match
+
+" Keywords
+syntax keyword lfKeywords target import main realtime reactor state time mutable input output timer
+      \ action reaction startup shutdown after deadline mutation preamble new federated at as from
+syntax keyword lfActionOrigins logical physical
+syntax keyword lfTimeUnits nsec nsecs usec usecs msec msecs sec secs second seconds
+      \ min mins minute minutes hour hours day days week weeks
+
+highlight def link lfKeywords Keyword
+highlight def link lfActionOrigins Keyword
+highlight def link lfTimeUnits StorageClass
+
+" Matches
+syntax match lfComment :\(#.*$\|//.*$\):
+hi def link lfComment Comment
+syntax match lfTargetDelim :\({=\|=}\):
+hi def link lfTargetDelim Delimiter
+
+" Regions
+execute "syntax include @TARGET ". LFGetSyntaxFile()
+syntax region lfTargetLang keepend start=/{=/ contains=@TARGET end=/=}/
+
+syntax region lfBlockComment start=:/\*: end=:\*/:
+hi def link lfBlockComment Comment
+
+syntax region lfString start=:": skip=:\\": end=:":
+hi def link lfString String
+
+let b:current_syntax = "linguafranca"


### PR DESCRIPTION
This is a little Vimscript code to add a Lingua Franca filetype to (neo)vim that I've written that others may benefit from.
It brings basic syntax highlighting and rudimentary text-object support for the target code blocks.

It can be installed by copying the three directories (`ftplugin`, `ftdetect`, `syntax`) and their content into:

- `~/.vim/` if you're using Vim
- `~/.config/nvim/` if you're using Neovim
- Or really anywhere in your Vim `'runtimepath'`

(One can of course, simply copy the content of the directories if they already exist).