### PR TITLE
Show printed messages in the console view of the LF IDE

### DIFF
--- a/org.lflang.ui/META-INF/MANIFEST.MF
+++ b/org.lflang.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,8 @@ Require-Bundle: org.lflang,
  org.eclipse.xtext.xbase.lib;bundle-version="2.14.0",
  org.eclipse.xtend.lib;bundle-version="2.14.0";resolution:=optional,
  org.eclipse.ui.intro,
- org.eclipse.ui.intro.universal
+ org.eclipse.ui.intro.universal,
+ org.eclipse.ui.console;bundle-version="3.10.100"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: org.lflang.ui.internal,

--- a/org.lflang.ui/src/org/lflang/ui/LFUiModule.xtend
+++ b/org.lflang.ui/src/org/lflang/ui/LFUiModule.xtend
@@ -20,6 +20,10 @@ import org.eclipse.xtext.ui.editor.autoedit.SingleLineTerminalsStrategy
 import com.google.inject.Provider
 import org.eclipse.xtext.resource.containers.IAllContainersState
 
+import org.eclipse.ui.console.MessageConsole
+import org.eclipse.ui.console.ConsolePlugin
+import java.io.PrintStream
+
 /**
  * Use this class to register components to be used within the Eclipse IDE.
  * 
@@ -31,6 +35,8 @@ import org.eclipse.xtext.resource.containers.IAllContainersState
  */
 @FinalFieldsConstructor
 class LFUiModule extends AbstractLFUiModule {
+    
+    static var consoleInitialized = false
     
     // Instead of classpath, use Properties -> Project Reference
     override Provider<IAllContainersState> provideIAllContainersState() {
@@ -132,8 +138,26 @@ class LFUiModule extends AbstractLFUiModule {
             acceptor.accept(new LFMultiLineTerminalsEditStrategy("{=", "=}", true), IDocument.DEFAULT_CONTENT_TYPE)
         }
         
+        /**
+         * Ensure that all text printed via println() is shown in the Console of the LF IDE.
+         */
+        protected def configureConsole() {
+            if (!consoleInitialized) {
+                val console = new MessageConsole("LF Output", null)
+                ConsolePlugin.getDefault().getConsoleManager().addConsoles(newArrayList(console))
+                ConsolePlugin.getDefault().getConsoleManager().showConsoleView(console)
+                val stream = console.newMessageStream()
+
+                System.setOut(new PrintStream(stream))
+                System.setErr(new PrintStream(stream))
+
+                consoleInitialized = true
+            }
+        }
+
         /** Specify these new acceptors. */
         override void configure(IEditStrategyAcceptor acceptor) {
+            configureConsole()
             configureMultilineCodeBlock(acceptor)
             super.configure(acceptor)
             configureCodeBlock(acceptor)


### PR DESCRIPTION
As the title says, this change redirects all messages printed via `println()` to the internal Console view of our IDE. Effectively, this makes all messages appear in the internal view of our IDE and no longer in the host IDE if running from Eclipse (or on the command line when running the product).

I am not sure where the best place is to put this code. The `LFUiModule` class was the best place I could find, and it seems to work well. We probably should also consider introducing some logging mechanism that lets us distinguish between messages we want to show the user in the Command view and other messages that are only interesting to developers.