### PR TITLE
Better platform abstraction for lf_clock_gettime() and _LF_CLOCK

### DIFF
--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -159,7 +159,7 @@ extern int lf_cond_wait(lf_cond_t* cond, lf_mutex_t* mutex);
  * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
  *  number otherwise.
  */
-extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, long long absolute_time_ns);
+extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absolute_time_ns);
 
 #endif
 

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -65,6 +65,24 @@ typedef _lf_thread_t lf_thread_t;        // Type to hold handle to a thread
 typedef _lf_time_spec_t lf_time_spec_t;  // Type to hold time in a traditional {second, nanosecond} POSIX format
 typedef _lf_clock_t lf_clock_t;          // Type to hold a clock identifier (e.g., CLOCK_REALTIME on POSIX)
 
+/**
+ * Time instant. Both physical and logical times are represented
+ * using this typedef.
+ * WARNING: If this code is used after about the year 2262,
+ * then representing time as a 64-bit long long will be insufficient.
+ */
+typedef long long instant_t;
+
+/**
+ * Interval of time.
+ */
+typedef long long interval_t;
+
+/**
+ * Microstep instant.
+ */
+typedef unsigned int microstep_t;
+
 #ifdef NUMBER_OF_WORKERS
 
 /**
@@ -148,8 +166,13 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, long long absol
 #endif
 
 /**
+ * Initialize the LF clock. Must be called before using other clock-related APIs.
+ */
+extern void lf_initialize_clock();
+
+/**
  * Fetch the value of an internal (and platform-specific) physical clock and 
- * store it in `tp`. 
+ * store it in `tp`.
  * 
  * Ideally, the underlying platform clock should be monotonic. However, the
  * core lib tries to enforce monotonicity at higher level APIs (see tag.h).

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -68,20 +68,18 @@ typedef _lf_clock_t lf_clock_t;          // Type to hold a clock identifier (e.g
 /**
  * Time instant. Both physical and logical times are represented
  * using this typedef.
- * WARNING: If this code is used after about the year 2262,
- * then representing time as a 64-bit long long will be insufficient.
  */
-typedef long long instant_t;
+typedef _instant_t instant_t;
 
 /**
  * Interval of time.
  */
-typedef long long interval_t;
+typedef _interval_t interval_t;
 
 /**
  * Microstep instant.
  */
-typedef unsigned int microstep_t;
+typedef _microstep_t microstep_t;
 
 #ifdef NUMBER_OF_WORKERS
 

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -62,7 +62,6 @@ typedef _lf_cond_t lf_cond_t;            // Type to hold handle to a condition v
 typedef _lf_thread_t lf_thread_t;        // Type to hold handle to a thread
 #endif
 
-typedef _lf_time_spec_t lf_time_spec_t;  // Type to hold time in a traditional {second, nanosecond} POSIX format
 typedef _lf_clock_t lf_clock_t;          // Type to hold a clock identifier (e.g., CLOCK_REALTIME on POSIX)
 
 /**
@@ -170,20 +169,20 @@ extern void lf_initialize_clock();
 
 /**
  * Fetch the value of an internal (and platform-specific) physical clock and 
- * store it in `tp`.
+ * store it in `t`.
  * 
  * Ideally, the underlying platform clock should be monotonic. However, the
  * core lib tries to enforce monotonicity at higher level APIs (see tag.h).
  * 
  * @return 0 for success, or -1 for failure
  */
-extern int lf_clock_gettime(lf_time_spec_t* tp);
+extern int lf_clock_gettime(instant_t* t);
 
 /**
  * Pause execution for a number of nanoseconds.
  * 
  * @return 0 for success, or -1 for failure.
  */
-extern int lf_nanosleep(const lf_time_spec_t* requested_time, lf_time_spec_t* remaining);
+extern int lf_nanosleep(instant_t requested_time);
 
 #endif // PLATFORM_H

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -70,6 +70,8 @@ typedef _lf_clock_t lf_clock_t;          // Type to hold a clock identifier (e.g
 /**
  * Create a new thread, starting with execution of lf_thread
  * getting passed arguments. The new handle is stored in thread_id.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments);
 
@@ -77,43 +79,59 @@ extern int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), vo
  * Make calling thread wait for termination of the thread.  The
  * exit status of the thread is stored in thread_return, if thread_return
  * is not NULL.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_thread_join(lf_thread_t thread, void** thread_return);
 
 /**
  * Initialize a mutex.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_mutex_init(lf_mutex_t* mutex);
 
 /**
  * Lock a mutex.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_mutex_lock(lf_mutex_t* mutex);
 
 /** 
  * Unlock a mutex.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_mutex_unlock(lf_mutex_t* mutex);
 
 
 /** 
  * Initialize a conditional variable.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_cond_init(lf_cond_t* cond);
 
 /** 
  * Wake up all threads waiting for condition variable cond.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_cond_broadcast(lf_cond_t* cond);
 
 /** 
  * Wake up one thread waiting for condition variable cond.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_cond_signal(lf_cond_t* cond);
 
 /** 
  * Wait for condition variable "cond" to be signaled or broadcast.
  * "mutex" is assumed to be locked before.
+ * 
+ * @return 0 on success, platform-specific error number otherwise.
  */
 extern int lf_cond_wait(lf_cond_t* cond, lf_mutex_t* mutex);
 
@@ -122,7 +140,8 @@ extern int lf_cond_wait(lf_cond_t* cond, lf_mutex_t* mutex);
  * pointed by "cond" is signaled or time pointed by "absolute_time_ns" in
  * nanoseconds is reached.
  * 
- * @return 0 on success and LF_TIMEOUT on timeout.
+ * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
+ *  number otherwise.
  */
 extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, long long absolute_time_ns);
 
@@ -130,18 +149,20 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, long long absol
 
 /**
  * Fetch the value of an internal (and platform-specific) physical clock and 
- * store it in tp. 
+ * store it in `tp`. 
  * 
  * Ideally, the underlying platform clock should be monotonic. However, the
- * core lib tries to enforce monotonicity at higher level APIs (see tag.h). 
- * Nonetheless, if the underlying clock is not monotonic, it can result in 
- * identical timestamps being presented to the user programs that use those APIs.
+ * core lib tries to enforce monotonicity at higher level APIs (see tag.h).
+ * 
+ * @return 0 for success, or -1 for failure
  */
 extern int lf_clock_gettime(lf_time_spec_t* tp);
 
 /**
  * Pause execution for a number of nanoseconds.
+ * 
+ * @return 0 for success, or -1 for failure.
  */
-extern int lf_nanosleep(lf_clock_t clk_id, const lf_time_spec_t* requested_time, lf_time_spec_t* remaining);
+extern int lf_nanosleep(const lf_time_spec_t* requested_time, lf_time_spec_t* remaining);
 
 #endif // PLATFORM_H

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -24,9 +24,19 @@ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************/
 
-/** Platform API support for the C target of Lingua Franca.
+/**
+ * Platform API support for the C target of Lingua Franca.
+ * This file detects the platform on which the C compiler is being run
+ * (e.g. Windows, Linux, Mac) and conditionally includes platform-specific
+ * files that define core datatypes and function signatures for Lingua Franca.
+ * For example, the type instant_t represents a time value (long long on
+ * most of the platforms). The conditionally included files define a type
+ * _instant_t, and this file defines the type instant_t to be whatever
+ * the included defines _instant_t to be. All platform-independent code
+ * in Lingua Franca, therefore, should use the type instant_t for time
+ * values.
  *  
- *  @author{Soroush Bateni <soroush@utdallas.edu>}
+ * @author{Soroush Bateni <soroush@utdallas.edu>}
  */
 
 #ifndef PLATFORM_H

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -129,9 +129,15 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, long long absol
 #endif
 
 /**
- * Fetch the value of clk_id and store it in tp.
+ * Fetch the value of an internal (and platform-specific) physical clock and 
+ * store it in tp. 
+ * 
+ * Ideally, the underlying platform clock should be monotonic. However, the
+ * core lib tries to enforce monotonicity at higher level APIs (see tag.h). 
+ * Nonetheless, if the underlying clock is not monotonic, it can result in 
+ * identical timestamps being presented to the user programs that use those APIs.
  */
-extern int lf_clock_gettime(lf_clock_t clk_id, lf_time_spec_t* tp);
+extern int lf_clock_gettime(lf_time_spec_t* tp);
 
 /**
  * Pause execution for a number of nanoseconds.

--- a/org.lflang/src/lib/core/platform/lf_C11_threads_support.c
+++ b/org.lflang/src/lib/core/platform/lf_C11_threads_support.c
@@ -35,6 +35,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /**
  * Create a new thread, starting with execution of lf_thread
  * getting passed arguments. The new handle is stored in thread.
+ *
+ * @return 0 on success, error number otherwise (see thrd_create()).
  */
 int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {
     return thrd_create((thrd_t*)thread, (thrd_start_t)lf_thread, arguments);
@@ -44,6 +46,8 @@ int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* ar
  * Make calling thread wait for termination of the thread.  The
  * exit status of the thread is stored in thread_return, if thread_return
  * is not NULL.
+ *
+ * @return 0 on success, error number otherwise (see thrd_join()).
  */
 int lf_thread_join(_lf_thread_t thread, void** thread_return) {
     thread_return = (void**)malloc(sizeof(void*));
@@ -53,6 +57,8 @@ int lf_thread_join(_lf_thread_t thread, void** thread_return) {
 
 /**
  * Initialize a mutex.
+ *
+ * @return 0 on success, error number otherwise (see mtx_init()).
  */
 int lf_mutex_init(_lf_mutex_t* mutex) {
     // Set up a timed and recursive mutex (default behavior)
@@ -61,6 +67,8 @@ int lf_mutex_init(_lf_mutex_t* mutex) {
 
 /**
  * Lock a mutex.
+ *
+ * @return 0 on success, error number otherwise (see mtx_lock()).
  */
 int lf_mutex_lock(_lf_mutex_t* mutex) {
     return mtx_lock((mtx_t*) mutex);
@@ -68,6 +76,8 @@ int lf_mutex_lock(_lf_mutex_t* mutex) {
 
 /** 
  * Unlock a mutex.
+ *
+ * @return 0 on success, error number otherwise (see mtx_unlock()).
  */
 int lf_mutex_unlock(_lf_mutex_t* mutex) {
     return mtx_unlock((mtx_t*) mutex);
@@ -75,6 +85,8 @@ int lf_mutex_unlock(_lf_mutex_t* mutex) {
 
 /** 
  * Initialize a conditional variable.
+ *
+ * @return 0 on success, error number otherwise (see cnd_init()).
  */
 int lf_cond_init(_lf_cond_t* cond) {
     return cnd_init((cnd_t*)cond);
@@ -82,6 +94,8 @@ int lf_cond_init(_lf_cond_t* cond) {
 
 /** 
  * Wake up all threads waiting for condition variable cond.
+ *
+ * @return 0 on success, error number otherwise (see cnd_broadcast()).
  */
 int lf_cond_broadcast(_lf_cond_t* cond) {
     return cnd_broadcast((cnd_t*)cond);
@@ -89,6 +103,8 @@ int lf_cond_broadcast(_lf_cond_t* cond) {
 
 /** 
  * Wake up one thread waiting for condition variable cond.
+ *
+ * @return 0 on success, error number otherwise (see cnd_signal()).
  */
 int lf_cond_signal(_lf_cond_t* cond) {
     return cnd_signal((cnd_t*)cond);
@@ -97,6 +113,8 @@ int lf_cond_signal(_lf_cond_t* cond) {
 /** 
  * Wait for condition variable "cond" to be signaled or broadcast.
  * "mutex" is assumed to be locked before.
+ *
+ * @return 0 on success, error number otherwise (see cnd_wait()).
  */
 int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
     return cnd_wait((cnd_t*)cond, (mtx_t*)mutex);
@@ -105,14 +123,29 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
 /** 
  * Block current thread on the condition variable until condition variable
  * pointed by "cond" is signaled or time pointed by "absolute_time_ns" in
- * nanoseconds is reached.
+ * nanoseconds is reached. 
  * 
- * @return 0 on success and LF_TIMEOUT on timeout.
+ * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
+ *  number otherwise (see pthread_cond_timedwait).
  */
 int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, long long absolute_time_ns) {
     // Convert the absolute time to a timespec.
     // timespec is seconds and nanoseconds.
     struct timespec timespec_absolute_time
             = {(time_t)absolute_time_ns / 1000000000LL, (long)absolute_time_ns % 1000000000LL};
-    return cnd_timedwait((cnd_t*)cond, (mtx_t*)mutex, &timespec_absolute_time);
+    int return_value = 0;
+    return_value = cnd_timedwait(
+        (cnd_t*)cond, 
+        (mtx_t*)mutex, 
+        &timespec_absolute_time
+    );
+    switch (return_value) {
+        case thrd_timedout:
+            return_value = _LF_TIMEOUT;
+            break;
+        
+        default:
+            break;
+    }
+    return return_value;
 }

--- a/org.lflang/src/lib/core/platform/lf_POSIX_threads_support.c
+++ b/org.lflang/src/lib/core/platform/lf_POSIX_threads_support.c
@@ -32,10 +32,13 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "lf_POSIX_threads_support.h"
+#include "errno.h"
 
 /**
- * Create a new thread, starting with execution of lf_thread
- * getting passed arguments. The new handle is stored in thread.
+ * Create a new thread, starting with execution of lf_thread getting passed
+ * arguments. The new handle is stored in thread.
+ *
+ * @return 0 on success, error number otherwise (see pthread_create()).
  */
 int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {
     return pthread_create((pthread_t*)thread, NULL, lf_thread, arguments);
@@ -45,6 +48,8 @@ int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* ar
  * Make calling thread wait for termination of the thread.  The
  * exit status of the thread is stored in thread_return, if thread_return
  * is not NULL.
+ *
+ * @return 0 on success, error number otherwise (see pthread_join()).
  */
 int lf_thread_join(_lf_thread_t thread, void** thread_return) {
     return pthread_join((pthread_t)thread, thread_return);
@@ -52,6 +57,8 @@ int lf_thread_join(_lf_thread_t thread, void** thread_return) {
 
 /**
  * Initialize a mutex.
+ *
+ * @return 0 on success, error number otherwise (see pthread_mutex_init()).
  */
 int lf_mutex_init(_lf_mutex_t* mutex) {
     // Set up a recursive mutex
@@ -63,6 +70,8 @@ int lf_mutex_init(_lf_mutex_t* mutex) {
 
 /**
  * Lock a mutex.
+ *
+ * @return 0 on success, error number otherwise (see pthread_mutex_lock()).
  */
 int lf_mutex_lock(_lf_mutex_t* mutex) {
     return pthread_mutex_lock((pthread_mutex_t*)mutex);
@@ -70,6 +79,8 @@ int lf_mutex_lock(_lf_mutex_t* mutex) {
 
 /** 
  * Unlock a mutex.
+ *
+ * @return 0 on success, error number otherwise (see pthread_mutex_unlock()).
  */
 int lf_mutex_unlock(_lf_mutex_t* mutex) {
     return pthread_mutex_unlock((pthread_mutex_t*)mutex);
@@ -77,6 +88,8 @@ int lf_mutex_unlock(_lf_mutex_t* mutex) {
 
 /** 
  * Initialize a conditional variable.
+ *
+ * @return 0 on success, error number otherwise (see pthread_cond_init()).
  */
 int lf_cond_init(_lf_cond_t* cond) {
     pthread_condattr_t cond_attr;
@@ -88,6 +101,8 @@ int lf_cond_init(_lf_cond_t* cond) {
 
 /** 
  * Wake up all threads waiting for condition variable cond.
+ *
+ * @return 0 on success, error number otherwise (see pthread_cond_broadcast()).
  */
 int lf_cond_broadcast(_lf_cond_t* cond) {
     return pthread_cond_broadcast((pthread_cond_t*)cond);
@@ -95,6 +110,8 @@ int lf_cond_broadcast(_lf_cond_t* cond) {
 
 /** 
  * Wake up one thread waiting for condition variable cond.
+ *
+ * @return 0 on success, error number otherwise (see pthread_cond_signal()).
  */
 int lf_cond_signal(_lf_cond_t* cond) {
     return pthread_cond_signal((pthread_cond_t*)cond);
@@ -103,6 +120,8 @@ int lf_cond_signal(_lf_cond_t* cond) {
 /** 
  * Wait for condition variable "cond" to be signaled or broadcast.
  * "mutex" is assumed to be locked before.
+ *
+ * @return 0 on success, error number otherwise (see pthread_cond_wait()).
  */
 int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
     return pthread_cond_wait((pthread_cond_t*)cond, (pthread_mutex_t*)mutex);
@@ -113,15 +132,27 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
  * pointed by "cond" is signaled or time pointed by "absolute_time_ns" in
  * nanoseconds is reached.
  * 
- * @return 0 on success and LF_TIMEOUT on timeout.
+ * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
+ *  number otherwise (see pthread_cond_timedwait).
  */
 int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, long long absolute_time_ns) {
     // Convert the absolute time to a timespec.
     // timespec is seconds and nanoseconds.
     struct timespec timespec_absolute_time
             = {(time_t)absolute_time_ns / 1000000000LL, (long)absolute_time_ns % 1000000000LL};
-    return pthread_cond_timedwait(
-                        (pthread_cond_t*)cond,
-                        (pthread_mutex_t*)mutex,
-                        &timespec_absolute_time);
+    int return_value = 0;
+    return_value = pthread_cond_timedwait(
+        (pthread_cond_t*)cond,
+        (pthread_mutex_t*)mutex,
+        &timespec_absolute_time
+    );
+    switch (return_value) {
+        case ETIMEDOUT:
+            return_value = _LF_TIMEOUT;
+            break;
+        
+        default:
+            break;
+    }
+    return return_value;
 }

--- a/org.lflang/src/lib/core/platform/lf_linux_support.c
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.c
@@ -42,7 +42,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /**
- * Fetch the value of _LF_CLOCK and store it in tp.
+ * Fetch the value of _LF_CLOCK (see lf_linux_support.h) and store it in tp.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set appropriately (see `man 2 clock_gettime`).
  */
 int lf_clock_gettime(_lf_time_spec_t* tp) {
     return clock_gettime(_LF_CLOCK, (struct timespec*) tp);
@@ -50,7 +53,10 @@ int lf_clock_gettime(_lf_time_spec_t* tp) {
 
 /**
  * Pause execution for a number of nanoseconds.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set appropriately (see `man 2 clock_nanosleep`).
  */
-int lf_nanosleep(_lf_clock_t clk_id, const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
-    return clock_nanosleep(clk_id, 0, (const struct timespec*)requested_time, (struct timespec*)remaining);
+int lf_nanosleep(const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
+    return clock_nanosleep(_LF_CLOCK, 0, (const struct timespec*)requested_time, (struct timespec*)remaining);
 }

--- a/org.lflang/src/lib/core/platform/lf_linux_support.c
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.c
@@ -42,10 +42,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /**
- * Fetch the value of clk_id and store it in tp.
+ * Fetch the value of _LF_CLOCK and store it in tp.
  */
-int lf_clock_gettime(_lf_clock_t clk_id, _lf_time_spec_t* tp) {
-    return clock_gettime((clockid_t)clk_id, (struct timespec*) tp);
+int lf_clock_gettime(_lf_time_spec_t* tp) {
+    return clock_gettime(_LF_CLOCK, (struct timespec*) tp);
 }
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_linux_support.c
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.c
@@ -44,36 +44,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lf_unix_clock_support.c"
 
 /**
- * Offset to _LF_CLOCK that would convert it
- * to epoch time.
- * For CLOCK_REALTIME, this offset is always zero.
- * For CLOCK_MONOTONIC, it is the difference between those
- * clocks at the start of the execution.
- */
-interval_t _lf_epoch_offset = 0LL;
-
-/**
- * Initialize the LF clock.
- */
-void lf_initialize_clock() {
-    _lf_epoch_offset = calculate_epoch_offset(_LF_CLOCK);
-}
-
-/**
- * Fetch the value of _LF_CLOCK (see lf_linux_support.h) and store it in tp. The
- * timestamp value in 'tp' will always be epoch time, which is the number of
- * nanoseconds since January 1st, 1970.
- *
- * @return 0 for success, or -1 for failure. In case of failure, errno will be
- *  set appropriately (see `man 2 clock_gettime`).
- */
-int lf_clock_gettime(_lf_time_spec_t* tp) {
-    // Adjust the clock by the epoch offset, so epoch time is always reported.
-    return clock_gettime(_LF_CLOCK, (struct timespec*) tp) + _lf_epoch_offset;
-}
-
-/**
  * Pause execution for a number of nanoseconds.
+ *
+ * A Linux-specific clock_nanosleep is used underneath that is supposedly more
+ * accurate.
  *
  * @return 0 for success, or -1 for failure. In case of failure, errno will be
  *  set appropriately (see `man 2 clock_nanosleep`).

--- a/org.lflang/src/lib/core/platform/lf_linux_support.c
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.c
@@ -52,6 +52,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @return 0 for success, or -1 for failure. In case of failure, errno will be
  *  set appropriately (see `man 2 clock_nanosleep`).
  */
-int lf_nanosleep(const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
-    return clock_nanosleep(_LF_CLOCK, 0, (const struct timespec*)requested_time, (struct timespec*)remaining);
+int lf_nanosleep(instant_t requested_time) {
+    const struct timespec tp = convert_ns_to_timespec(requested_time);
+    struct timespec remaining;
+    return clock_nanosleep(_LF_CLOCK, 0, (const struct timespec*)&tp, (struct timespec*)&remaining);
 }

--- a/org.lflang/src/lib/core/platform/lf_linux_support.h
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.h
@@ -40,7 +40,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_linux_support.h
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.h
@@ -43,4 +43,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
+// The underlying physical clock for Linux
+#define _LF_CLOCK CLOCK_MONOTONIC
+
 #endif // LF_LINUX_SUPPORT_H

--- a/org.lflang/src/lib/core/platform/lf_linux_support.h
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.h
@@ -43,6 +43,25 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
+/**
+ * Time instant. Both physical and logical times are represented
+ * using this typedef.
+ * WARNING: If this code is used after about the year 2262,
+ * then representing time as a 64-bit long long will be insufficient.
+ */
+typedef long long _instant_t;
+
+/**
+ * Interval of time.
+ */
+typedef long long _interval_t;
+
+/**
+ * Microstep instant.
+ */
+typedef unsigned int _microstep_t;
+
+
 // The underlying physical clock for Linux
 #define _LF_CLOCK CLOCK_MONOTONIC
 

--- a/org.lflang/src/lib/core/platform/lf_macos_support.c
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.c
@@ -42,10 +42,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /**
- * Fetch the value of clk_id and store it in tp.
+ * Fetch the value of _LF_CLOCK and store it in tp.
  */
-int lf_clock_gettime(_lf_clock_t clk_id, _lf_time_spec_t* tp) {
-    return clock_gettime((clockid_t)clk_id, (struct timespec*) tp);
+int lf_clock_gettime(_lf_time_spec_t* tp) {
+    return clock_gettime(_LF_CLOCK, (struct timespec*) tp);
 }
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_macos_support.c
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.c
@@ -42,7 +42,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 /**
- * Fetch the value of _LF_CLOCK and store it in tp.
+ * Fetch the value of _LF_CLOCK (see lf_macos_support.h) and store it in tp.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set appropriately (see `man 2 clock_gettime`).
  */
 int lf_clock_gettime(_lf_time_spec_t* tp) {
     return clock_gettime(_LF_CLOCK, (struct timespec*) tp);
@@ -50,7 +53,10 @@ int lf_clock_gettime(_lf_time_spec_t* tp) {
 
 /**
  * Pause execution for a number of nanoseconds.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set appropriately (see `man 2 clock_nanosleep`).
  */
-int lf_nanosleep(_lf_clock_t clk_id, const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
+int lf_nanosleep(const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
     return nanosleep((const struct timespec*)requested_time, (struct timespec*)remaining);
 }

--- a/org.lflang/src/lib/core/platform/lf_macos_support.c
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.c
@@ -49,6 +49,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @return 0 for success, or -1 for failure. In case of failure, errno will be
  *  set appropriately (see `man 2 clock_nanosleep`).
  */
-int lf_nanosleep(const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
-    return nanosleep((const struct timespec*)requested_time, (struct timespec*)remaining);
+int lf_nanosleep(instant_t requested_time) {
+    const struct timespec tp = convert_ns_to_timespec(requested_time);
+    struct timespec remaining;
+    return nanosleep((const struct timespec*)&tp, (struct timespec*)&remaining);
 }

--- a/org.lflang/src/lib/core/platform/lf_macos_support.c
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.c
@@ -41,14 +41,35 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
+#include "lf_unix_clock_support.c"
+
 /**
- * Fetch the value of _LF_CLOCK (see lf_macos_support.h) and store it in tp.
+ * Offset to _LF_CLOCK that would convert it
+ * to epoch time.
+ * For CLOCK_REALTIME, this offset is always zero.
+ * For CLOCK_MONOTONIC, it is the difference between those
+ * clocks at the start of the execution.
+ */
+interval_t _lf_epoch_offset = 0LL;
+
+/**
+ * Initialize the LF clock.
+ */
+void lf_initialize_clock() {
+    _lf_epoch_offset = calculate_epoch_offset(_LF_CLOCK);
+}
+
+/**
+ * Fetch the value of _LF_CLOCK (see lf_macos_support.h) and store it in tp. The
+ * timestamp value in 'tp' will always be epoch time, which is the number of
+ * nanoseconds since January 1st, 1970.
  *
  * @return 0 for success, or -1 for failure. In case of failure, errno will be
  *  set appropriately (see `man 2 clock_gettime`).
  */
 int lf_clock_gettime(_lf_time_spec_t* tp) {
-    return clock_gettime(_LF_CLOCK, (struct timespec*) tp);
+    // Adjust the clock by the epoch offset, so epoch time is always reported.
+    return clock_gettime(_LF_CLOCK, (struct timespec*) tp) + _lf_epoch_offset;
 }
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_macos_support.c
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.c
@@ -44,35 +44,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "lf_unix_clock_support.c"
 
 /**
- * Offset to _LF_CLOCK that would convert it
- * to epoch time.
- * For CLOCK_REALTIME, this offset is always zero.
- * For CLOCK_MONOTONIC, it is the difference between those
- * clocks at the start of the execution.
- */
-interval_t _lf_epoch_offset = 0LL;
-
-/**
- * Initialize the LF clock.
- */
-void lf_initialize_clock() {
-    _lf_epoch_offset = calculate_epoch_offset(_LF_CLOCK);
-}
-
-/**
- * Fetch the value of _LF_CLOCK (see lf_macos_support.h) and store it in tp. The
- * timestamp value in 'tp' will always be epoch time, which is the number of
- * nanoseconds since January 1st, 1970.
- *
- * @return 0 for success, or -1 for failure. In case of failure, errno will be
- *  set appropriately (see `man 2 clock_gettime`).
- */
-int lf_clock_gettime(_lf_time_spec_t* tp) {
-    // Adjust the clock by the epoch offset, so epoch time is always reported.
-    return clock_gettime(_LF_CLOCK, (struct timespec*) tp) + _lf_epoch_offset;
-}
-
-/**
  * Pause execution for a number of nanoseconds.
  *
  * @return 0 for success, or -1 for failure. In case of failure, errno will be

--- a/org.lflang/src/lib/core/platform/lf_macos_support.h
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.h
@@ -43,6 +43,24 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
+/**
+ * Time instant. Both physical and logical times are represented
+ * using this typedef.
+ * WARNING: If this code is used after about the year 2262,
+ * then representing time as a 64-bit long long will be insufficient.
+ */
+typedef long long _instant_t;
+
+/**
+ * Interval of time.
+ */
+typedef long long _interval_t;
+
+/**
+ * Microstep instant.
+ */
+typedef unsigned int _microstep_t;
+
 // The underlying physical clock for MacOS
 #define _LF_CLOCK CLOCK_MONOTONIC
 

--- a/org.lflang/src/lib/core/platform/lf_macos_support.h
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.h
@@ -40,7 +40,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_macos_support.h
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.h
@@ -43,4 +43,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
+// The underlying physical clock for MacOS
+#define _LF_CLOCK CLOCK_MONOTONIC
+
 #endif // LF_MACOS_SUPPORT_H

--- a/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
+++ b/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
@@ -2,27 +2,93 @@
 #include <time.h>
 
 /**
- * Calculate the necessary offset to bring 'clock_id' in parity with the epoch
+ * Offset to _LF_CLOCK that would convert it
+ * to epoch time.
+ * For CLOCK_REALTIME, this offset is always zero.
+ * For CLOCK_MONOTONIC, it is the difference between those
+ * clocks at the start of the execution.
+ */
+interval_t _lf_epoch_offset = 0LL;
+
+/**
+ * Convert a _lf_time_spec_t ('tp') to an instant_t representation in
+ * nanoseconds.
+ *
+ * @return nanoseconds (long long).
+ */
+instant_t convert_timespec_to_ns(_lf_time_spec_t tp) {
+    return tp.tv_sec * 1000000000 + tp.tv_nsec;
+}
+
+/**
+ * Convert an instant_t ('t') representation in nanoseconds to a
+ * _lf_time_spec_t.
+ *
+ * @return _lf_time_spec_t representation of 't'.
+ */
+_lf_time_spec_t convert_ns_to_timespec(instant_t t) {
+    _lf_time_spec_t tp;
+    tp.tv_sec = t / 1000000000;
+    tp.tv_nsec = (t % 1000000000);
+    return tp;
+}
+
+/**
+ * Calculate the necessary offset to bring _LF_CLOCK in parity with the epoch
  * time reported by CLOCK_REALTIME.
  */
-long long calculate_epoch_offset(int clock_id) {
-    long long epoch_offset;
-    if (clock_id == CLOCK_REALTIME) {
+void calculate_epoch_offset() {
+    if (_LF_CLOCK == CLOCK_REALTIME) {
         // Set the epoch offset to zero (see tag.h)
-        epoch_offset = 0LL;
+        _lf_epoch_offset = 0LL;
     } else {
         // Initialize _lf_epoch_offset to the difference between what is
         // reported by whatever clock LF is using (e.g. CLOCK_MONOTONIC) and
         // what is reported by CLOCK_REALTIME.
         struct timespec physical_clock_snapshot, real_time_start;
 
-        clock_gettime(clock_id, &physical_clock_snapshot);
-        long long physical_clock_snapshot_ns = physical_clock_snapshot.tv_sec * 1000000000 + physical_clock_snapshot.tv_nsec;
+        clock_gettime(_LF_CLOCK, &physical_clock_snapshot);
+        long long physical_clock_snapshot_ns = convert_timespec_to_ns(physical_clock_snapshot);
+
 
         clock_gettime(CLOCK_REALTIME, &real_time_start);
-        long long real_time_start_ns = real_time_start.tv_sec * 1000000000 + real_time_start.tv_nsec;
+        long long real_time_start_ns = convert_timespec_to_ns(real_time_start);
 
-        epoch_offset = real_time_start_ns - physical_clock_snapshot_ns;
+        _lf_epoch_offset = real_time_start_ns - physical_clock_snapshot_ns;
     }
-    return epoch_offset;
+}
+
+/**
+ * Initialize the LF clock.
+ */
+void lf_initialize_clock() {
+    calculate_epoch_offset();
+}
+
+/**
+ * Fetch the value of _LF_CLOCK (see lf_linux_support.h) and store it in tp. The
+ * timestamp value in 'tp' will always be epoch time, which is the number of
+ * nanoseconds since January 1st, 1970.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set appropriately (see `man 2 clock_gettime`).
+ */
+int lf_clock_gettime(_lf_time_spec_t* tp) {
+    // Adjust the clock by the epoch offset, so epoch time is always reported.
+    int return_value = clock_gettime(_LF_CLOCK, (struct timespec*) tp);
+    if (return_value < 0) {
+        return return_value;
+    }
+
+    // We need to apply the epoch offset if it is not zero
+    if (_lf_epoch_offset != 0) {
+        // Here, we do a costly conversion from _lf_time_spec_t to nanoseconds,
+        // add the epoch offset, and then convert back to _lf_time_spec_t. The
+        // reason is simply to account for overflows from tv_nsec to tv_sec when
+        // applying the offset.
+        instant_t tp_in_ns = convert_timespec_to_ns(*tp);
+        tp_in_ns += _lf_epoch_offset;
+        *tp = convert_ns_to_timespec(tp_in_ns);
+    }
+    return return_value;
 }

--- a/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
+++ b/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
@@ -86,10 +86,6 @@ int lf_clock_gettime(instant_t* t) {
 
     // We need to apply the epoch offset if it is not zero
     if (_lf_epoch_offset != 0) {
-        // Here, we do a costly conversion from _lf_time_spec_t to nanoseconds,
-        // add the epoch offset, and then convert back to _lf_time_spec_t. The
-        // reason is simply to account for overflows from tv_nsec to tv_sec when
-        // applying the offset.
         tp_in_ns += _lf_epoch_offset;
     }
     

--- a/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
+++ b/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
@@ -2,8 +2,8 @@
 #include <time.h>
 
 /**
- * Calculate the necessary offset to bring _LF_CLOCK in parity with the epoch
- * time.
+ * Calculate the necessary offset to bring 'clock_id' in parity with the epoch
+ * time reported by CLOCK_REALTIME.
  */
 long long calculate_epoch_offset(int clock_id) {
     long long epoch_offset;

--- a/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
+++ b/org.lflang/src/lib/core/platform/lf_unix_clock_support.c
@@ -1,0 +1,28 @@
+
+#include <time.h>
+
+/**
+ * Calculate the necessary offset to bring _LF_CLOCK in parity with the epoch
+ * time.
+ */
+long long calculate_epoch_offset(int clock_id) {
+    long long epoch_offset;
+    if (clock_id == CLOCK_REALTIME) {
+        // Set the epoch offset to zero (see tag.h)
+        epoch_offset = 0LL;
+    } else {
+        // Initialize _lf_epoch_offset to the difference between what is
+        // reported by whatever clock LF is using (e.g. CLOCK_MONOTONIC) and
+        // what is reported by CLOCK_REALTIME.
+        struct timespec physical_clock_snapshot, real_time_start;
+
+        clock_gettime(clock_id, &physical_clock_snapshot);
+        long long physical_clock_snapshot_ns = physical_clock_snapshot.tv_sec * 1000000000 + physical_clock_snapshot.tv_nsec;
+
+        clock_gettime(CLOCK_REALTIME, &real_time_start);
+        long long real_time_start_ns = real_time_start.tv_sec * 1000000000 + real_time_start.tv_nsec;
+
+        epoch_offset = real_time_start_ns - physical_clock_snapshot_ns;
+    }
+    return epoch_offset;
+}

--- a/org.lflang/src/lib/core/platform/lf_windows_support.c
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.c
@@ -47,6 +47,8 @@ NtQuerySystemTime_t *NtQuerySystemTime = NULL;
 /**
  * Create a new thread, starting with execution of lf_thread
  * getting passed arguments. The new handle is stored in thread.
+ * 
+ * @return 0 on success, 1 otherwise.
  */
 int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {
     uintptr_t handle = _beginthread((windows_thread)lf_thread,0,arg);
@@ -62,6 +64,8 @@ int lf_thread_create(_lf_thread_t* thread, void *(*lf_thread) (void *), void* ar
  * Make calling thread wait for termination of the thread.  The
  * exit status of the thread is stored in thread_return, if thread_return
  * is not NULL.
+ * 
+ * @return 0 on success, EINVAL otherwise.
  */
 int lf_thread_join(_lf_thread_t thread, void** thread_return) {    
 	DWORD retvalue = WaitForSingleObject(thread.handle,INFINITE);
@@ -74,6 +78,8 @@ int lf_thread_join(_lf_thread_t thread, void** thread_return) {
 
 /**
  * Initialize a critical section.
+ * 
+ * @return 0 on success, 1 otherwise.
  */
 int lf_mutex_init(_lf_critical_section_t* critical_section) {
     // Set up a recursive mutex
@@ -93,40 +99,56 @@ int lf_mutex_init(_lf_critical_section_t* critical_section) {
  *     The timeout interval is specified by the following registry value: 
  *     HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\CriticalSectionTimeout.
  *     Do not handle a possible deadlock exception; instead, debug the application."
+ * 
+ * @return 0
  */
 int lf_mutex_lock(_lf_critical_section_t* critical_section) {
+    // The following Windows API does not return a value. It can
+    // raise a EXCEPTION_POSSIBLE_DEADLOCK. See synchapi.h.
 	EnterCriticalSection((CRITICAL_SECTION*)critical_section);
     return 0;
 }
 
 /** 
  * Leave a critical_section.
+ * 
+ * @return 0
  */
 int lf_mutex_unlock(_lf_critical_section_t* critical_section) {
+    // The following Windows API does not return a value.
     LeaveCriticalSection((CRITICAL_SECTION*)critical_section);
     return 0;
 }
 
 /** 
  * Initialize a conditional variable.
+ * 
+ * @return 0
  */
 int lf_cond_init(_lf_cond_t* cond) {
+    // The following Windows API does not return a value.
     InitializeConditionVariable((CONDITION_VARIABLE*)cond);
     return 0;
 }
 
 /** 
  * Wake up all threads waiting for condition variable cond.
+ * 
+ * @return 0
  */
 int lf_cond_broadcast(_lf_cond_t* cond) {
+    // The following Windows API does not return a value.
     WakeAllConditionVariable((CONDITION_VARIABLE*)cond);
     return 0;
 }
 
 /** 
  * Wake up one thread waiting for condition variable cond.
+ * 
+ * @return 0
  */
 int lf_cond_signal(_lf_cond_t* cond) {
+    // The following Windows API does not return a value.
     WakeConditionVariable((CONDITION_VARIABLE*)cond);
     return 0;
 }
@@ -134,9 +156,29 @@ int lf_cond_signal(_lf_cond_t* cond) {
 /** 
  * Wait for condition variable "cond" to be signaled or broadcast.
  * "mutex" is assumed to be locked before.
+ * 
+ * @return 0 on success, 1 otherwise.
  */
 int lf_cond_wait(_lf_cond_t* cond, _lf_critical_section_t* critical_section) {
-    return (int)SleepConditionVariableCS((CONDITION_VARIABLE*)cond, (CRITICAL_SECTION*)critical_section, INFINITE);
+    // According to synchapi.h, the following Windows API returns 0 on failure,
+    // and non-zero on success.
+    int return_value =
+     (int)SleepConditionVariableCS(
+         (CONDITION_VARIABLE*)cond, 
+         (CRITICAL_SECTION*)critical_section, 
+         INFINITE
+     );
+     switch (return_value) {
+        case 0:
+            // Error
+            return 1;
+            break;
+        
+        default:
+            // Success
+            return 0;
+            break;
+     }
 }
 
 /** 
@@ -144,52 +186,79 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_critical_section_t* critical_section) {
  * pointed by "cond" is signaled or time pointed by "absolute_time_ns" in
  * nanoseconds is reached.
  * 
- * @return 0 on success and LF_TIMEOUT on timeout.
+ * @return 0 on success and LF_TIMEOUT on timeout, 1 otherwise.
  */
 int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section, instant_t absolute_time_ns) {
     // Convert the absolute time to a relative time
     DWORD relative_time_ms = (absolute_time_ns - get_physical_time())/1000000LL;
 
-    return (int)SleepConditionVariableCS((CONDITION_VARIABLE*)cond, (CRITICAL_SECTION*)critical_section, relative_time_ms);
+    int return_value =
+     (int)SleepConditionVariableCS(
+         (CONDITION_VARIABLE*)cond, 
+         (CRITICAL_SECTION*)critical_section, 
+         relative_time_ms
+     );
+     switch (return_value) {
+        case 0:
+            // Error
+            if (GetLastError() == ERROR_TIMEOUT) {
+                return _LF_TIMEOUT;
+            }
+            return 1;
+            break;
+        
+        default:
+            // Success
+            return 0;
+            break;
+     }
 }
 
 /**
- * Fetch the value _LF_CLOCK and store it in tp.
+ * Fetch the value of _LF_CLOCK (see lf_windows_support.h) and store it in tp.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set to EINVAL.
  */
 int lf_clock_gettime(_lf_time_spec_t* tp) {
     int result = -1;
     int days_from_1601_to_1970 = 134774 /* there were no leap seconds during this time, so life is easy */;
     long long timestamp, counts, counts_per_sec;
     switch (_LF_CLOCK) {
-    case CLOCK_REALTIME:
-        NtQuerySystemTime((PLARGE_INTEGER)&timestamp);
-        timestamp -= days_from_1601_to_1970 * 24LL * 60 * 60 * 1000 * 1000 * 10;
-        tp->tv_sec = (time_t)(timestamp / (BILLION / 100));
-        tp->tv_nsec = (long)((timestamp % (BILLION / 100)) * 100);
-        result = 0;
-        break;
-    case CLOCK_MONOTONIC:
-        if ((*NtQueryPerformanceCounter)((PLARGE_INTEGER)&counts, (PLARGE_INTEGER)&counts_per_sec) == 0) {
-            tp->tv_sec = counts / counts_per_sec;
-            tp->tv_nsec = (long)((counts % counts_per_sec) * BILLION / counts_per_sec);
+        case CLOCK_REALTIME:
+            NtQuerySystemTime((PLARGE_INTEGER)&timestamp);
+            timestamp -= days_from_1601_to_1970 * 24LL * 60 * 60 * 1000 * 1000 * 10;
+            tp->tv_sec = (time_t)(timestamp / (BILLION / 100));
+            tp->tv_nsec = (long)((timestamp % (BILLION / 100)) * 100);
             result = 0;
-        } else {
+            break;
+        case CLOCK_MONOTONIC:
+            if ((*NtQueryPerformanceCounter)((PLARGE_INTEGER)&counts, (PLARGE_INTEGER)&counts_per_sec) == 0) {
+                tp->tv_sec = counts / counts_per_sec;
+                tp->tv_nsec = (long)((counts % counts_per_sec) * BILLION / counts_per_sec);
+                result = 0;
+            } else {
+                errno = EINVAL;
+                result = -1;
+            }
+            break;
+        default:
             errno = EINVAL;
             result = -1;
-        }
-        break;
-    default:
-        errno = EINVAL;
-        result = -1;
-        break;
+            break;
     }
     return result;
 }
 
 /**
  * Pause execution for a number of nanoseconds.
+ *
+ * @return 0 for success, or -1 for failure. In case of failure, errno will be
+ *  set to 
+ *   - EINTR: The sleep was interrupted by a signal handler
+ *   - EINVAL: All other errors
  */
-int lf_nanosleep(_lf_clock_t clk_id, const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
+int lf_nanosleep(const _lf_time_spec_t* requested_time, _lf_time_spec_t* remaining) {
     unsigned char alertable = remaining ? 1 : 0;
     long long duration = -(requested_time->tv_sec * (BILLION / 100) + requested_time->tv_nsec / 100);
     NTSTATUS status = (*NtDelayExecution)(alertable, (PLARGE_INTEGER)&duration);

--- a/org.lflang/src/lib/core/platform/lf_windows_support.c
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.c
@@ -154,13 +154,13 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
 }
 
 /**
- * Fetch the value of clk_id and store it in tp.
+ * Fetch the value _LF_CLOCK and store it in tp.
  */
-int lf_clock_gettime(_lf_clock_t clk_id, _lf_time_spec_t* tp) {
+int lf_clock_gettime(_lf_time_spec_t* tp) {
     int result = -1;
     int days_from_1601_to_1970 = 134774 /* there were no leap seconds during this time, so life is easy */;
     long long timestamp, counts, counts_per_sec;
-    switch (clk_id) {
+    switch (_LF_CLOCK) {
     case CLOCK_REALTIME:
         NtQuerySystemTime((PLARGE_INTEGER)&timestamp);
         timestamp -= days_from_1601_to_1970 * 24LL * 60 * 60 * 1000 * 1000 * 10;

--- a/org.lflang/src/lib/core/platform/lf_windows_support.h
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.h
@@ -68,5 +68,8 @@ typedef int _lf_clock_t;
 
 #define _LF_TIMEOUT ETIMEDOUT
 
+// The underlying physical clock for Windows
+#define _LF_CLOCK CLOCK_MONOTONIC
+
 #endif // LF_WINDOWS_SUPPORT_H
 

--- a/org.lflang/src/lib/core/platform/lf_windows_support.h
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.h
@@ -63,7 +63,6 @@ typedef HANDLE _lf_thread_t;
 #endif
 #endif
 
-typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
 /**

--- a/org.lflang/src/lib/core/platform/lf_windows_support.h
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.h
@@ -66,6 +66,24 @@ typedef HANDLE _lf_thread_t;
 typedef struct timespec _lf_time_spec_t;
 typedef int _lf_clock_t;
 
+/**
+ * Time instant. Both physical and logical times are represented
+ * using this typedef.
+ * WARNING: If this code is used after about the year 2262,
+ * then representing time as a 64-bit long long will be insufficient.
+ */
+typedef long long _instant_t;
+
+/**
+ * Interval of time.
+ */
+typedef long long _interval_t;
+
+/**
+ * Microstep instant.
+ */
+typedef unsigned int _microstep_t;
+
 #define _LF_TIMEOUT ETIMEDOUT
 
 // The underlying physical clock for Windows

--- a/org.lflang/src/lib/core/reactor.c
+++ b/org.lflang/src/lib/core/reactor.c
@@ -38,6 +38,16 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //#include <assert.h>
 
 /**
+ * Unless the "fast" option is given, an LF program will wait until
+ * physical time matches logical time before handling an event with
+ * a given logical time. The amount of time is less than this given
+ * threshold, then no wait will occur. The purpose of this is
+ * to prevent unnecessary delays caused by simply setting up and
+ * performing the wait.
+ */
+#define MIN_WAIT_TIME NSEC(10)
+
+/**
  * Schedule the specified trigger at current_tag.time plus the offset of the
  * specified trigger plus the delay.
  * See reactor.h for documentation.
@@ -97,16 +107,13 @@ int wait_until(instant_t logical_time_ns) {
         LOG_PRINT("Waiting for elapsed logical time %lld.", logical_time_ns - start_time);
         interval_t ns_to_wait = logical_time_ns - get_physical_time();
     
-        if (ns_to_wait <= 0) {
+        if (ns_to_wait < MIN_WAIT_TIME) {
+            DEBUG_PRINT("Wait time %lld is less than MIN_WAIT_TIME %lld. Skipping wait.",
+                ns_to_wait, MIN_WAIT_TIME);
             return return_value;
         }
-    
-        // timespec is seconds and nanoseconds.
-        struct timespec wait_time = {(time_t)ns_to_wait / BILLION, (long)ns_to_wait % BILLION};
-        DEBUG_PRINT("Waiting %lld seconds, %lld nanoseconds.", ns_to_wait / BILLION, ns_to_wait % BILLION);
-        struct timespec remaining_time;
-        // FIXME: If the wait time is less than the time resolution, don't sleep.
-        return_value = lf_nanosleep(&wait_time, &remaining_time);
+
+        return_value = lf_nanosleep(ns_to_wait);
     }
     return return_value;
 }

--- a/org.lflang/src/lib/core/reactor.c
+++ b/org.lflang/src/lib/core/reactor.c
@@ -106,7 +106,7 @@ int wait_until(instant_t logical_time_ns) {
         DEBUG_PRINT("Waiting %lld seconds, %lld nanoseconds.", ns_to_wait / BILLION, ns_to_wait % BILLION);
         struct timespec remaining_time;
         // FIXME: If the wait time is less than the time resolution, don't sleep.
-        return_value = lf_nanosleep(_LF_CLOCK, &wait_time, &remaining_time);
+        return_value = lf_nanosleep(&wait_time, &remaining_time);
     }
     return return_value;
 }

--- a/org.lflang/src/lib/core/reactor.h
+++ b/org.lflang/src/lib/core/reactor.h
@@ -60,7 +60,8 @@
 #include <errno.h>
 #include "pqueue.h"
 #include "util.h"
-#include "tag.h"    // Time-related types and functions.
+#include "tag.h"       // Time-related functions.
+#include "platform.h"  // Platform-specific times and APIs
 
 // The following file is also included, but must be included
 // after its requirements are met, so the #include appears at

--- a/org.lflang/src/lib/core/reactor_common.c
+++ b/org.lflang/src/lib/core/reactor_common.c
@@ -1786,31 +1786,6 @@ int process_args(int argc, char* argv[]) {
 }
 
 /**
- * Calculate the necessary offset to bring _LF_CLOCK in parity
- * with the epoch time.
- */
-void calculate_epoch_offset() {
-    if (_LF_CLOCK == CLOCK_REALTIME) {
-        // Set the epoch offset to zero (see tag.h)
-        _lf_epoch_offset = 0LL;
-    } else {
-        // Initialize _lf_epoch_offset to the difference between what is
-        // reported by whatever clock LF is using (e.g. CLOCK_MONOTONIC)
-        // and what is reported by CLOCK_REALTIME.
-        struct timespec physical_clock_snapshot, real_time_start;
-
-        clock_gettime(_LF_CLOCK, &physical_clock_snapshot);
-        instant_t physical_clock_snapshot_ns = physical_clock_snapshot.tv_sec * BILLION + physical_clock_snapshot.tv_nsec;
-
-        clock_gettime(CLOCK_REALTIME, &real_time_start);
-        instant_t real_time_start_ns = real_time_start.tv_sec * BILLION + real_time_start.tv_nsec;
-
-        _lf_epoch_offset = real_time_start_ns - physical_clock_snapshot_ns;
-    }
-    LOG_PRINT("Clock sync: Initial epoch offset set to %lld.", _lf_epoch_offset);
-}
-
-/**
  * Initialize the priority queues and set logical time to match
  * physical time. This also prints a message reporting the start time.
  */

--- a/org.lflang/src/lib/core/tag.c
+++ b/org.lflang/src/lib/core/tag.c
@@ -193,8 +193,8 @@ instant_t _lf_last_reported_unadjusted_physical_time_ns = NEVER;
  */
 instant_t get_physical_time() {
     // Get the current clock value
-    struct timespec physicalTime;
-    lf_clock_gettime(_LF_CLOCK, &physicalTime);
+    lf_time_spec_t physicalTime;
+    lf_clock_gettime(&physicalTime);
     _lf_last_reported_unadjusted_physical_time_ns = (physicalTime.tv_sec * BILLION + physicalTime.tv_nsec)
             + _lf_epoch_offset;
     

--- a/org.lflang/src/lib/core/tag.c
+++ b/org.lflang/src/lib/core/tag.c
@@ -34,15 +34,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 
 /**
- * Offset to _LF_CLOCK that would convert it
- * to epoch time.
- * For CLOCK_REALTIME, this offset is always zero.
- * For CLOCK_MONOTONIC, it is the difference between those
- * clocks at the start of the execution.
- */
-interval_t _lf_epoch_offset = 0LL;
-
-/**
  * Current time in nanoseconds since January 1, 1970
  * This is not in scope for reactors.
  * This should only ever be accessed while holding the mutex lock.
@@ -195,8 +186,7 @@ instant_t get_physical_time() {
     // Get the current clock value
     lf_time_spec_t physicalTime;
     lf_clock_gettime(&physicalTime);
-    _lf_last_reported_unadjusted_physical_time_ns = (physicalTime.tv_sec * BILLION + physicalTime.tv_nsec)
-            + _lf_epoch_offset;
+    _lf_last_reported_unadjusted_physical_time_ns = (physicalTime.tv_sec * BILLION + physicalTime.tv_nsec);
     
     // Adjust the reported clock with the appropriate offsets
     instant_t adjusted_clock_ns = _lf_last_reported_unadjusted_physical_time_ns

--- a/org.lflang/src/lib/core/tag.c
+++ b/org.lflang/src/lib/core/tag.c
@@ -184,9 +184,7 @@ instant_t _lf_last_reported_unadjusted_physical_time_ns = NEVER;
  */
 instant_t get_physical_time() {
     // Get the current clock value
-    lf_time_spec_t physicalTime;
-    lf_clock_gettime(&physicalTime);
-    _lf_last_reported_unadjusted_physical_time_ns = (physicalTime.tv_sec * BILLION + physicalTime.tv_nsec);
+    lf_clock_gettime(&_lf_last_reported_unadjusted_physical_time_ns);
     
     // Adjust the reported clock with the appropriate offsets
     instant_t adjusted_clock_ns = _lf_last_reported_unadjusted_physical_time_ns

--- a/org.lflang/src/lib/core/tag.h
+++ b/org.lflang/src/lib/core/tag.h
@@ -61,9 +61,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Convenience for converting times
 #define BILLION 1000000000LL
 
-// The underlying physical clock
-#define _LF_CLOCK CLOCK_MONOTONIC
-
 /**
  * Time instant. Both physical and logical times are represented
  * using this typedef.

--- a/org.lflang/src/lib/core/tag.h
+++ b/org.lflang/src/lib/core/tag.h
@@ -62,24 +62,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BILLION 1000000000LL
 
 /**
- * Time instant. Both physical and logical times are represented
- * using this typedef.
- * WARNING: If this code is used after about the year 2262,
- * then representing time as a 64-bit long long will be insufficient.
- */
-typedef long long instant_t;
-
-/**
- * Interval of time.
- */
-typedef long long interval_t;
-
-/**
- * Microstep instant.
- */
-typedef unsigned int microstep_t;
-
-/**
  * A tag is a time, microstep pair.
  */
 typedef struct {

--- a/org.lflang/src/lib/core/tag.h
+++ b/org.lflang/src/lib/core/tag.h
@@ -33,6 +33,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef TAG_H
 #define TAG_H
 
+#include "platform.h"
+
 /* Conversion of time to nanoseconds. */
 #define NSEC(t) (t * 1LL)
 #define NSECS(t) (t * 1LL)

--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -659,10 +659,9 @@ class CGenerator extends GeneratorBase {
                 
                 setReactionPriorities(main, federate)
                 
-                // Calculate the epoch offset so that subsequent calls
-                // to get_physical_time() return epoch time.
+                // Initialize the LF clock.
                 pr('''
-                    calculate_epoch_offset();
+                    lf_initialize_clock();
                 ''')
                 
                 initializeFederate(federate)

--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -414,6 +414,7 @@ class CGenerator extends GeneratorBase {
             coreFiles.add("platform/lf_C11_threads_support.h")
             coreFiles.add("platform/lf_macos_support.c")            
             coreFiles.add("platform/lf_macos_support.h")
+            coreFiles.add("platform/lf_unix_clock_support.c")
             // If there is no main reactor, then compilation will produce a .o file requiring further linking.
             if (mainDef !== null) {
                 targetConfig.compileAdditionalSources.add(fileConfig.getSrcGenPath + File.separator + "core/platform/lf_macos_support.c")
@@ -424,6 +425,8 @@ class CGenerator extends GeneratorBase {
             coreFiles.add("platform/lf_C11_threads_support.h")
             coreFiles.add("platform/lf_windows_support.c")
             coreFiles.add("platform/lf_windows_support.h")
+            // For 64-bit epoch time
+            coreFiles.add("platform/lf_unix_clock_support.c")
             // If there is no main reactor, then compilation will produce a .o file requiring further linking.
             if (mainDef !== null) {
                 targetConfig.compileAdditionalSources.add(fileConfig.getSrcGenPath + File.separator + "core/platform/lf_windows_support.c")
@@ -436,6 +439,7 @@ class CGenerator extends GeneratorBase {
             coreFiles.add("platform/lf_C11_threads_support.h")
             coreFiles.add("platform/lf_linux_support.c")
             coreFiles.add("platform/lf_linux_support.h")
+            coreFiles.add("platform/lf_unix_clock_support.c")
             // If there is no main reactor, then compilation will produce a .o file requiring further linking.
             if (mainDef !== null) {
                 targetConfig.compileAdditionalSources.add(fileConfig.getSrcGenPath + File.separator + "core/platform/lf_linux_support.c")


### PR DESCRIPTION
This makes _LF_CLOCK, which is platform-dependent, an internal property of the given platform's implementation files.

A consequence of that is a backward-incompatible change to lf_clock_gettime(). Any platform support library in the future would have to change (e.g., the RISCV bare-metal support).

This also makes get_physical_time() more platform independent, mainly by using the new lf_clock_gettime().