### PR TITLE
FIXMEs and minor changes discussed during code review

### DIFF
--- a/org.lflang/src/lib/C/ctarget.h
+++ b/org.lflang/src/lib/C/ctarget.h
@@ -144,6 +144,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Schedule an action to occur with the specified value and time offset
  * with no payload (no value conveyed).
  * See schedule_token(), which this uses, for details.
+ * 
  * @param action Pointer to an action on the self struct.
  * @param offset The time offset over and above that in the action.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
@@ -153,9 +154,15 @@ handle_t schedule(void* action, interval_t offset) {
 }
 
 /**
- * Variant of schedule_value when the value is an integer.
- * See reactor.h for documentation.
- * @param action Pointer to an action on the self struct.
+ * Schedule the specified action with an integer value at a later logical
+ * time that depends on whether the action is logical or physical and
+ * what its parameter values are. This wraps a copy of the integer value
+ * in a token. See schedule_token() for more details.
+ * 
+ * @param action The action to be triggered.
+ * @param extra_delay Extra offset of the event release above that in the action.
+ * @param value The value to send.
+ * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
 handle_t schedule_int(void* action, interval_t extra_delay, int value)
 {
@@ -163,30 +170,114 @@ handle_t schedule_int(void* action, interval_t extra_delay, int value)
 }
 
 /**
- * Schedule the specified trigger at current_time plus the offset of the
- * specified trigger plus the delay.
- * See reactor.h for documentation.
+ * Schedule the specified action with the specified token as a payload.
+ * This will trigger an event at a later logical time that depends
+ * on whether the action is logical or physical and what its parameter
+ * values are.
+ *
+ * logical action: A logical action has an offset (default is zero)
+ * and a minimum interarrival time (MIT), which also defaults to zero.
+ * The logical time at which this scheduled event will trigger is
+ * the current time plus the offset plus the delay argument given to
+ * this function. If, however, that time is not greater than a prior
+ * triggering of this logical action by at least the MIT, then the
+ * one of two things can happen depending on the policy specified
+ * for the action. If the action's policy is DROP (default), then the
+ * action is simply dropped and the memory pointed to by value argument
+ * is freed. If the policy is DEFER, then the time will be increased
+ * to equal the time of the most recent triggering plus the MIT.
+ *
+ * For the above, "current time" means the logical time of the
+ * reaction that is calling this function. Logical actions should
+ * always be scheduled within a reaction invocation, never asynchronously
+ * from the outside. FIXME: This needs to be checked.
+ *
+ * physical action: A physical action has all the same parameters
+ * as a logical action, but its timestamp will be the larger of the
+ * current physical time and the time it would be assigned if it
+ * were a logical action.
+ *
+ * The token is required to be either NULL or a pointer to
+ * a token created using create_token().
+ *
+ * There are three conditions under which this function will not
+ * actually put an event on the event queue and decrement the reference count
+ * of the token (if there is one), which could result in the payload being
+ * freed. In all three cases, this function returns 0. Otherwise,
+ * it returns a handle to the scheduled trigger, which is an integer
+ * greater than 0.
+ *
+ * The first condition is that stop() has been called and the time offset
+ * of this event is greater than zero.
+ * The second condition is that the logical time of the event
+ * is greater that the stop time (timeout) that is specified in the target
+ * properties or on the command line.
+ * The third condition is that the trigger argument is null.
+ *
+ * @param action The action to be triggered.
+ * @param extra_delay Extra offset of the event release above that in the action.
+ * @param token The token to carry the payload or null for no payload.
+ * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
 handle_t schedule_token(void* action, interval_t extra_delay, lf_token_t* token) {
     return _lf_schedule_token(action, extra_delay, token);
 }
 
 /**
- * Schedule an action to occur with the specified value and time offset
- * with a copy of the specified value.
- * See reactor.h for documentation.
+ * Schedule an action to occur with the specified value and time offset with a
+ * copy of the specified value. If the value is non-null, then it will be copied
+ * into newly allocated memory under the assumption that its size is given in
+ * the trigger's token object's element_size field multiplied by the specified
+ * length.
+ * 
+ * See schedule_token(), which this uses, for details.
+ *
+ * @param action Pointer to an action on a self struct.
+ * @param offset The time offset over and above that in the action.
+ * @param value A pointer to the value to copy.
+ * @param length The length, if an array, 1 if a scalar, and 0 if value is NULL.
+ * @return A handle to the event, or 0 if no event was scheduled, or -1 for
+ *  error.
  */
 handle_t schedule_copy(void* action, interval_t offset, void* value, int length) {
-    return _lf_schedule_copy(action, offset, value, length);
+    if (length < 0) {
+        error_print(
+            "schedule_copy():"
+            " Ignoring request to copy a value with a negative length (%d).",
+            length
+        );
+        return -1;
+    }
+    return _lf_schedule_copy(action, offset, value, (size_t)length);
 }
 
 
 /**
  * Variant of schedule_token that creates a token to carry the specified value.
- * See reactor.h for documentation.
+ * The value is required to be malloc'd memory with a size equal to the
+ * element_size of the specifies action times the length parameter.
+ *
+ * See schedule_token(), which this uses, for details.
+ *
+ * @param action The action to be triggered.
+ * @param extra_delay Extra offset of the event release above that in the
+ *  action.
+ * @param value Dynamically allocated memory containing the value to send.
+ * @param length The length of the array, if it is an array, or 1 for a scalar
+ *  and 0 for no payload.
+ * @return A handle to the event, or 0 if no event was scheduled, or -1 for
+ *  error.
  */
-handle_t schedule_value(void* action, interval_t extra_delay, void* value, int length) {
-    return _lf_schedule_value(action, extra_delay, value, length);
+handle_t schedule_value(void* action, interval_t extra_delay, void* value, int length) {    
+    if (length < 0) {
+        error_print(
+            "schedule_value():"
+            " Ignoring request to schedule an action with a value that has a negative length (%d).",
+            length
+        );
+        return -1;
+    }
+    return _lf_schedule_value(action, extra_delay, value, (size_t)length);
 }
 
 #endif // CTARGET_H

--- a/org.lflang/src/lib/Python/pythontarget.c
+++ b/org.lflang/src/lib/Python/pythontarget.c
@@ -95,7 +95,7 @@ static PyObject* py_SET(PyObject *self, PyObject *args) {
 /**
  * Prototype for the internal API. @see reactor_common.c
  **/
-lf_token_t* __initialize_token_with_value(lf_token_t* token, void* value, int length);
+lf_token_t* __initialize_token_with_value(lf_token_t* token, void* value, size_t length);
 
 /**
  * Prototype for API function. @see lib/core/reactor_common.c

--- a/org.lflang/src/lib/core/clock-sync.c
+++ b/org.lflang/src/lib/core/clock-sync.c
@@ -260,7 +260,7 @@ void synchronize_initial_physical_clock_with_rti(int rti_socket_TCP) {
  */
 int handle_T1_clock_sync_message(unsigned char* buffer, int socket, instant_t t2) {
     // Extract the payload
-    instant_t t1 = extract_ll(&(buffer[1]));
+    instant_t t1 = extract_int64(&(buffer[1]));
 
     DEBUG_PRINT("Received T1 message with time payload %lld from RTI at local time %lld.",
                 t1, t2);
@@ -274,7 +274,7 @@ int handle_T1_clock_sync_message(unsigned char* buffer, int socket, instant_t t2
     // Reply will have the federate ID as a payload.
     unsigned char reply_buffer[1 + sizeof(int)];
     reply_buffer[0] = MSG_TYPE_CLOCK_SYNC_T3;
-    encode_int(_lf_my_fed_id, &(reply_buffer[1]));
+    encode_int32(_lf_my_fed_id, &(reply_buffer[1]));
 
     // Write the reply to the socket.
     DEBUG_PRINT("Sending T3 message to RTI.");
@@ -311,7 +311,7 @@ void handle_T4_clock_sync_message(unsigned char* buffer, int socket, instant_t r
     _lf_rti_socket_stat.received_T4_messages_in_current_sync_window++;
 
     // Extract the payload
-    instant_t t4 = extract_ll(&(buffer[1]));
+    instant_t t4 = extract_int64(&(buffer[1]));
 
     DEBUG_PRINT("Clock sync: Received T4 message with time payload %lld from RTI at local time %lld. "
             "(difference %lld)",
@@ -354,7 +354,7 @@ void handle_T4_clock_sync_message(unsigned char* buffer, int socket, instant_t r
             return;
         }
         // Filter out noise.
-        instant_t t5 = extract_ll(&(buffer[1]));  // Time at the RTI of sending the coded probe.
+        instant_t t5 = extract_int64(&(buffer[1]));  // Time at the RTI of sending the coded probe.
 
         // Compare the difference in time at the RTI between sending T4 and the coded probe
         // against the difference in time at this federate of receiving these two message.

--- a/org.lflang/src/lib/core/clock-sync.c
+++ b/org.lflang/src/lib/core/clock-sync.c
@@ -343,11 +343,11 @@ void handle_T4_clock_sync_message(unsigned char* buffer, int socket, instant_t r
     if (socket == _lf_rti_socket_UDP) {
         // Read the coded probe message.
         // We can reuse the same buffer.
-        int bytes_read = read_from_socket(socket, 1 + sizeof(instant_t), buffer);
+        ssize_t bytes_read = read_from_socket(socket, 1 + sizeof(instant_t), buffer);
 
         instant_t r5 = get_physical_time();
 
-        if (bytes_read < (int)(1 + sizeof(instant_t))
+        if ((bytes_read < 1 + (ssize_t)sizeof(instant_t))
                 || buffer[0] != MSG_TYPE_CLOCK_SYNC_CODED_PROBE) {
             warning_print("Clock sync: Did not get the expected coded probe message from the RTI. "
                     "Skipping clock synchronization round.");
@@ -455,7 +455,7 @@ void* listen_to_rti_UDP_thread(void* args) {
     // Listen for UDP messages from the RTI.
     // The only expected messages are T1 and T4, which have
     // a payload of a time value.
-    int message_size = 1 + sizeof(instant_t);
+    size_t message_size = 1 + sizeof(instant_t);
     unsigned char buffer[message_size];
     // This thread will be either waiting for T1 or waiting
     // for T4. Track the mode with this variable:
@@ -467,12 +467,12 @@ void* listen_to_rti_UDP_thread(void* args) {
     while (1) {
         struct sockaddr_in RTI_UDP_addr;
         socklen_t RTI_UDP_addr_length = sizeof(RTI_UDP_addr);
-        int bytes_read = 0;
+        ssize_t bytes_read = 0;
         // Read from the UDP socket
         do {
-            int bytes = recvfrom(_lf_rti_socket_UDP,                    // The UDP socket
+            ssize_t bytes = recvfrom(_lf_rti_socket_UDP,                    // The UDP socket
                                     &buffer[bytes_read],                // The buffer to read into
-                                    message_size - bytes_read,          // Number of bytes to read
+                                    message_size - (size_t)bytes_read,  // Number of bytes to read
                                     MSG_WAITALL,                        // Read the entire datagram
                                     (struct sockaddr*)&RTI_UDP_addr,    // Record the RTI's address
                                     &RTI_UDP_addr_length);              // The RTI's address length

--- a/org.lflang/src/lib/core/federate.c
+++ b/org.lflang/src/lib/core/federate.c
@@ -100,7 +100,7 @@ void* listen_to_federates(void* args);
  * connections from remote federates. This function
  * only handles the creation of the server socket.
  * The reserved port for the server socket is then
- * sent to the RTI by sending an MSG_TYPE_ADDRESS_AD message
+ * sent to the RTI by sending an MSG_TYPE_ADDRESS_ADVERTISEMENT message
  * (@see rti.h). This function expects no response
  * from the RTI.
  * 
@@ -114,7 +114,7 @@ void* listen_to_federates(void* args);
  * @note This function is similar to create_server(...) in rti.c.
  * However, it contains specific log messages for the peer to
  * peer connections between federates. It also additionally 
- * sends an address advertisement (MSG_TYPE_ADDRESS_AD) message to the
+ * sends an address advertisement (MSG_TYPE_ADDRESS_ADVERTISEMENT) message to the
  * RTI informing it of the port.
  * 
  * @param specified_port The specified port by the user.
@@ -180,9 +180,9 @@ void create_server(int specified_port) {
     _fed.server_port = port;
 
     // Send the server port number to the RTI
-    // on an MSG_TYPE_ADDRESS_AD message (@see rti.h).
+    // on an MSG_TYPE_ADDRESS_ADVERTISEMENT message (@see rti.h).
     unsigned char buffer[sizeof(int) + 1];
-    buffer[0] = MSG_TYPE_ADDRESS_AD;
+    buffer[0] = MSG_TYPE_ADDRESS_ADVERTISEMENT;
     encode_int(_fed.server_port, &(buffer[1]));
     write_to_socket_errexit(_fed.socket_TCP_RTI, sizeof(int) + 1, (unsigned char*)buffer,
                     "Failed to send address advertisement.");
@@ -638,7 +638,7 @@ void connect_to_federate(ushort remote_federate_id) {
 
         // A reply of -1 for the port means that the RTI does not know
         // the port number of the remote federate, presumably because the
-        // remote federate has not yet sent an MSG_TYPE_ADDRESS_AD message to the RTI.
+        // remote federate has not yet sent an MSG_TYPE_ADDRESS_ADVERTISEMENT message to the RTI.
         // Sleep for some time before retrying.
         if (port == -1) {
             if (count_tries++ >= CONNECT_NUM_RETRIES) {

--- a/org.lflang/src/lib/core/federate.c
+++ b/org.lflang/src/lib/core/federate.c
@@ -1498,8 +1498,7 @@ void handle_port_absent_message(int socket, int fed_id) {
     // The next part of the message is the federate_id, but we don't need it.
     // unsigned short federate_id = extract_uint16(&(buffer[sizeof(ushort)]));
     tag_t intended_tag;
-    intended_tag.time = extract_int64(&(buffer[sizeof(ushort)+sizeof(ushort)]));
-    intended_tag.microstep = extract_int32(&(buffer[sizeof(ushort)+sizeof(ushort)+sizeof(instant_t)])); 
+    extract_tag(&(buffer[sizeof(ushort)+sizeof(ushort)]), &intended_tag.time, &intended_tag.microstep);
 
     LOG_PRINT("Handling port absent for tag (%lld, %u) for port %d.",
             intended_tag.time - start_time,
@@ -1763,8 +1762,7 @@ void handle_tag_advance_grant() {
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read tag advance grant from RTI.");
     tag_t TAG;
-    TAG.time = extract_int64(buffer);
-    TAG.microstep = extract_int32(&(buffer[sizeof(instant_t)]));
+    extract_tag(buffer, &TAG.time, &TAG.microstep);
 
     lf_mutex_lock(&mutex);
 
@@ -1841,8 +1839,7 @@ void handle_provisional_tag_advance_grant() {
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read provisional tag advance grant from RTI.");
     tag_t PTAG;
-    PTAG.time = extract_int64(buffer);
-    PTAG.microstep = extract_int32(&(buffer[sizeof(instant_t)]));
+    extract_tag(buffer, &PTAG.time, &PTAG.microstep);
 
     // Note: it is important that last_known_status_tag of ports does not
     // get updated to a PTAG value because a PTAG does not indicate that
@@ -1986,8 +1983,7 @@ void handle_stop_granted_message() {
     lf_mutex_lock(&mutex);
 
     tag_t received_stop_tag;
-    received_stop_tag.time = extract_int64(buffer);
-    received_stop_tag.microstep = extract_int32(&(buffer[sizeof(instant_t)]));
+    extract_tag(buffer, &received_stop_tag.time, &received_stop_tag.microstep);
 
     LOG_PRINT("Received from RTI a MSG_TYPE_STOP_GRANTED message with elapsed tag (%lld, %d).",
             received_stop_tag.time - start_time, received_stop_tag.microstep);
@@ -2040,8 +2036,7 @@ void handle_stop_request_message() {
     }
 
     tag_t tag_to_stop;
-    tag_to_stop.time = extract_int64(buffer); 
-    tag_to_stop.microstep = extract_int32(&(buffer[sizeof(instant_t)]));
+    extract_tag(buffer, &tag_to_stop.time, &tag_to_stop.microstep);
 
     LOG_PRINT("Received from RTI a MSG_TYPE_STOP_REQUEST message with tag (%lld, %u).",
              tag_to_stop.time - start_time,

--- a/org.lflang/src/lib/core/federate.c
+++ b/org.lflang/src/lib/core/federate.c
@@ -1549,7 +1549,7 @@ void handle_message(int socket, int fed_id) {
     // Extract the header information.
     unsigned short port_id;
     unsigned short federate_id;
-    unsigned int length;
+    size_t length;
     extract_header(buffer, &port_id, &federate_id, &length);
     // Check if the message is intended for this federate
     assert(_lf_my_fed_id == federate_id);
@@ -1598,7 +1598,7 @@ void handle_tagged_message(int socket, int fed_id) {
     // Extract the header information.
     unsigned short port_id;
     unsigned short federate_id;
-    unsigned int length;
+    size_t length;
     tag_t intended_tag;
     extract_timed_header(buffer, &port_id, &federate_id, &length, &intended_tag);
     // Check if the message is intended for this federate
@@ -1948,7 +1948,7 @@ void _lf_fd_send_stop_request_to_rti() {
     _lf_increment_global_tag_barrier_already_locked(current_tag);
 
     // Send a stop request with the current tag to the RTI
-    unsigned char buffer[STOP_REQUEST_MESSAGE_LENGTH];
+    unsigned char buffer[MSG_TYPE_STOP_REQUEST_LENGTH];
     // Stop at the next microstep
     ENCODE_STOP_REQUEST(buffer, current_tag.time, current_tag.microstep + 1);
 
@@ -1958,7 +1958,7 @@ void _lf_fd_send_stop_request_to_rti() {
         lf_mutex_unlock(&outbound_socket_mutex);
     	return;
     }
-    write_to_socket_errexit_with_mutex(_fed.socket_TCP_RTI, STOP_REQUEST_MESSAGE_LENGTH, 
+    write_to_socket_errexit_with_mutex(_fed.socket_TCP_RTI, MSG_TYPE_STOP_REQUEST_LENGTH, 
     		buffer, &outbound_socket_mutex,
             "Failed to send stop time %lld to the RTI.", current_tag.time - start_time);
     lf_mutex_unlock(&outbound_socket_mutex);
@@ -1976,7 +1976,7 @@ void _lf_fd_send_stop_request_to_rti() {
  * the mutex lock, therefore, it acquires it.
  */
 void handle_stop_granted_message() {
-    int bytes_to_read = STOP_GRANTED_MESSAGE_LENGTH - 1;
+    int bytes_to_read = MSG_TYPE_STOP_GRANTED_LENGTH - 1;
     unsigned char buffer[bytes_to_read];    
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read stop granted from RTI.");
@@ -2024,7 +2024,7 @@ void handle_stop_granted_message() {
  * the mutex lock, therefore, it acquires it.
  */
 void handle_stop_request_message() {
-    int bytes_to_read = STOP_REQUEST_MESSAGE_LENGTH - 1;
+    int bytes_to_read = MSG_TYPE_STOP_REQUEST_LENGTH - 1;
     unsigned char buffer[bytes_to_read];    
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read stop request from RTI.");
@@ -2055,7 +2055,7 @@ void handle_stop_request_message() {
         tag_to_stop.microstep++;
     }
 
-    unsigned char outgoing_buffer[STOP_REQUEST_REPLY_MESSAGE_LENGTH];
+    unsigned char outgoing_buffer[MSG_TYPE_STOP_REQUEST_REPLY_LENGTH];
     ENCODE_STOP_REQUEST_REPLY(outgoing_buffer, tag_to_stop.time, tag_to_stop.microstep);
 
     lf_mutex_lock(&outbound_socket_mutex);
@@ -2068,7 +2068,7 @@ void handle_stop_request_message() {
     // Send the current logical time to the RTI. This message does not have an identifying byte since
     // since the RTI is waiting for a response from this federate.
     write_to_socket_errexit_with_mutex(
-    		_fed.socket_TCP_RTI, STOP_REQUEST_REPLY_MESSAGE_LENGTH, outgoing_buffer, &outbound_socket_mutex,
+    		_fed.socket_TCP_RTI, MSG_TYPE_STOP_REQUEST_REPLY_LENGTH, outgoing_buffer, &outbound_socket_mutex,
             "Failed to send the answer to MSG_TYPE_STOP_REQUEST to RTI.");
     lf_mutex_unlock(&outbound_socket_mutex);
 

--- a/org.lflang/src/lib/core/federate.c
+++ b/org.lflang/src/lib/core/federate.c
@@ -90,7 +90,7 @@ federate_instance_t _fed = {
  * schedule an event. If an error occurs or an EOF is received 
  * from the peer, then this procedure returns, terminating the 
  * thread.
- * @param fed_id_ptr A pointer to a ushort containing federate ID being listened to.
+ * @param fed_id_ptr A pointer to a uint16_t containing federate ID being listened to.
  *  This procedure frees the memory pointed to before returning.
  */
 void* listen_to_federates(void* args);
@@ -120,7 +120,17 @@ void* listen_to_federates(void* args);
  * @param specified_port The specified port by the user.
  */
 void create_server(int specified_port) {
-    int port = specified_port;
+    if (specified_port > UINT16_MAX ||
+        specified_port < 0) {
+        error_print(
+            "create_server(): The specified port (%d) is out of range."
+            " Starting with %d instead.",
+            specified_port,
+            STARTING_PORT
+        );
+        specified_port = 0;
+    }
+    uint16_t port = (uint16_t)specified_port;
     if (specified_port == 0) {
         // Use the default starting port.
         port = STARTING_PORT;
@@ -181,10 +191,10 @@ void create_server(int specified_port) {
 
     // Send the server port number to the RTI
     // on an MSG_TYPE_ADDRESS_ADVERTISEMENT message (@see rti.h).
-    unsigned char buffer[sizeof(int) + 1];
+    unsigned char buffer[sizeof(int32_t) + 1];
     buffer[0] = MSG_TYPE_ADDRESS_ADVERTISEMENT;
     encode_int32(_fed.server_port, &(buffer[1]));
-    write_to_socket_errexit(_fed.socket_TCP_RTI, sizeof(int) + 1, (unsigned char*)buffer,
+    write_to_socket_errexit(_fed.socket_TCP_RTI, sizeof(int32_t) + 1, (unsigned char*)buffer,
                     "Failed to send address advertisement.");
     DEBUG_PRINT("Sent port %d to the RTI.", _fed.server_port);
 
@@ -220,23 +230,32 @@ int send_message(int message_type,
                   const char* next_destination_str,
                   size_t length,
                   unsigned char* message) {
-    unsigned char header_buffer[1 + sizeof(ushort) + sizeof(ushort) + sizeof(int)];
+    unsigned char header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t)];
     // First byte identifies this as a timed message.
-    header_buffer[0] = message_type;
+    if (message_type != MSG_TYPE_MESSAGE &&
+        message_type != MSG_TYPE_P2P_MESSAGE
+    ) {
+        error_print(
+            "send_message() was called with an invalid message type (%d).",
+            message_type
+        );
+        return 0;
+    }
+    header_buffer[0] = (unsigned char)message_type;
     // Next two bytes identify the destination port.
     // NOTE: Send messages little endian, not big endian.
     encode_uint16(port, &(header_buffer[1]));
 
     // Next two bytes identify the destination federate.
-    encode_uint16(federate, &(header_buffer[1 + sizeof(ushort)]));
+    encode_uint16(federate, &(header_buffer[1 + sizeof(uint16_t)]));
 
     // The next four bytes are the message length.
-    encode_int32(length, &(header_buffer[1 + sizeof(ushort) + sizeof(ushort)]));
+    encode_int32((int32_t)length, &(header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t)]));
 
     LOG_PRINT("Sending untimed message to %s.", next_destination_str);
 
     // Header:  message_type + port_id + federate_id + length of message + timestamp + microstep
-    const int header_length = 1 + sizeof(ushort) + sizeof(ushort) + sizeof(int);
+    const int header_length = 1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t);
     // Use a mutex lock to prevent multiple threads from simultaneously sending.
     lf_mutex_lock(&outbound_socket_mutex);
     // First, check that the socket is still connected. This must done
@@ -301,34 +320,51 @@ int send_timed_message(interval_t additional_delay,
                         const char* next_destination_str,
                         size_t length,
                         unsigned char* message) {
-    unsigned char header_buffer[1 + sizeof(ushort) + sizeof(ushort)
-             + sizeof(int) + sizeof(instant_t) + sizeof(microstep_t)];
+    unsigned char header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t)
+             + sizeof(int32_t) + sizeof(instant_t) + sizeof(microstep_t)];
     // First byte identifies this as a timed message.
-    header_buffer[0] = message_type;
+    if (message_type != MSG_TYPE_TAGGED_MESSAGE &&
+        message_type != MSG_TYPE_P2P_TAGGED_MESSAGE
+    ) {
+        error_print(
+            "send_message() was called with an invalid message type (%d).",
+            message_type
+        );
+        return 0;
+    }
+    size_t buffer_head = 0;
+    header_buffer[buffer_head] = (unsigned char)message_type;
+    buffer_head += sizeof(unsigned char);
     // Next two bytes identify the destination port.
     // NOTE: Send messages little endian, not big endian.
-    encode_uint16(port, &(header_buffer[1]));
+    encode_uint16(port, &(header_buffer[buffer_head]));
+    buffer_head += sizeof(uint16_t);
 
     // Next two bytes identify the destination federate.
-    encode_uint16(federate, &(header_buffer[1 + sizeof(ushort)]));
+    encode_uint16(federate, &(header_buffer[buffer_head]));
+    buffer_head += sizeof(uint16_t);
 
     // The next four bytes are the message length.
-    encode_int32(length, &(header_buffer[1 + sizeof(ushort) + sizeof(ushort)]));
+    encode_int32((int32_t)length, &(header_buffer[buffer_head]));
+    buffer_head += sizeof(int32_t);
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
     tag_t current_message_intended_tag = delay_tag(get_current_tag(),
                                                     additional_delay);
 
-    // Next 8 bytes are the timestamp.
-    encode_int64(current_message_intended_tag.time, &(header_buffer[1 + sizeof(ushort) + sizeof(ushort) + sizeof(int)]));
-    // Next 4 bytes are the microstep.
-    encode_int32(current_message_intended_tag.microstep, &(header_buffer[1 + sizeof(ushort) + sizeof(ushort) + sizeof(int) + sizeof(instant_t)]));
+    // Next 8 + 4 will be the tag (timestamp, microstep)
+    encode_tag(
+        &(header_buffer[buffer_head]), 
+        current_message_intended_tag
+    );
+    buffer_head += sizeof(int64_t) + sizeof(uint32_t);
+
     LOG_PRINT("Sending message with tag (%lld, %u) to %s.",
             current_message_intended_tag.time - start_time, current_message_intended_tag.microstep, next_destination_str);
 
     // Header:  message_type + port_id + federate_id + length of message + timestamp + microstep
-    const int header_length = 1 + sizeof(ushort) + sizeof(ushort) + sizeof(int) + sizeof(instant_t) + sizeof(microstep_t);
+    size_t header_length = buffer_head;
 
     if (_lf_is_tag_after_stop_tag(current_message_intended_tag)) {
         // Message tag is past the timeout time (the stop time) so it should
@@ -368,7 +404,7 @@ int send_timed_message(interval_t additional_delay,
  */
 void _lf_send_time(unsigned char type, instant_t time) {
     DEBUG_PRINT("Sending time %lld to the RTI.", time);
-    int bytes_to_write = 1 + sizeof(instant_t);
+    size_t bytes_to_write = 1 + sizeof(instant_t);
     unsigned char buffer[bytes_to_write];
     buffer[0] = type;
     encode_int64(time, &(buffer[1]));
@@ -378,8 +414,8 @@ void _lf_send_time(unsigned char type, instant_t time) {
         lf_mutex_unlock(&outbound_socket_mutex);
     	return;
     }
-    int bytes_written = write_to_socket(_fed.socket_TCP_RTI, bytes_to_write, buffer);
-    if (bytes_written < bytes_to_write) {
+    ssize_t bytes_written = write_to_socket(_fed.socket_TCP_RTI, bytes_to_write, buffer);
+    if (bytes_written < (ssize_t)bytes_to_write) {
         if (errno == ENOTCONN) {
             // FIXME: Shutdown is probably not working properly because the socket gets disconnected.
             error_print("Socket to the RTI is no longer connected. Considering this a soft error.");
@@ -404,19 +440,19 @@ void _lf_send_time(unsigned char type, instant_t time) {
  */
 void _lf_send_tag(unsigned char type, tag_t tag) {
     DEBUG_PRINT("Sending tag (%lld, %u) to the RTI.", tag.time - start_time, tag.microstep);
-    int bytes_to_write = 1 + sizeof(instant_t) + sizeof(microstep_t);
+    size_t bytes_to_write = 1 + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_write];
     buffer[0] = type;
-    encode_int64(tag.time, &(buffer[1]));
-    encode_int32(tag.microstep, &(buffer[1 + sizeof(instant_t)]));
+    encode_tag(&(buffer[1]), tag);
+
     lf_mutex_lock(&outbound_socket_mutex);
     if (_fed.socket_TCP_RTI < 0) {
     	warning_print("Socket is no longer connected. Dropping message.");
         lf_mutex_unlock(&outbound_socket_mutex);
     	return;
     }
-    int bytes_written = write_to_socket(_fed.socket_TCP_RTI, bytes_to_write, buffer);
-    if (bytes_written < bytes_to_write) {
+    ssize_t bytes_written = write_to_socket(_fed.socket_TCP_RTI, bytes_to_write, buffer);
+    if (bytes_written < (ssize_t)bytes_to_write) {
         if (errno == ENOTCONN) {
             error_print("Socket to the RTI is no longer connected. Considering this a soft error.");
         } else {
@@ -458,10 +494,10 @@ void* handle_p2p_connections_from_federates(void* ignored) {
         }
         LOG_PRINT("Accepted new connection from remote federate.");
 
-        int header_length = 1 + sizeof(ushort) + 1;
+        size_t header_length = 1 + sizeof(uint16_t) + 1;
         unsigned char buffer[header_length];
-        int bytes_read = read_from_socket(socket_id, header_length, (unsigned char*)&buffer);
-        if (bytes_read != header_length || buffer[0] != MSG_TYPE_P2P_SENDING_FED_ID) {
+        ssize_t bytes_read = read_from_socket(socket_id, header_length, (unsigned char*)&buffer);
+        if (bytes_read != (ssize_t)header_length || buffer[0] != MSG_TYPE_P2P_SENDING_FED_ID) {
             warning_print("Federate received invalid first message on P2P socket. Closing socket.");
             if (bytes_read >= 0) {
                 unsigned char response[2];
@@ -493,7 +529,7 @@ void* handle_p2p_connections_from_federates(void* ignored) {
         }
 
         // Extract the ID of the sending federate.
-        ushort remote_fed_id = extract_uint16((unsigned char*)&(buffer[1]));
+        uint16_t remote_fed_id = extract_uint16((unsigned char*)&(buffer[1]));
         DEBUG_PRINT("Received sending federate ID %d.", remote_fed_id);
 
         // Once we record the socket_id here, all future calls to close() on
@@ -513,7 +549,7 @@ void* handle_p2p_connections_from_federates(void* ignored) {
         // We cannot pass a pointer to remote_fed_id to the thread we need to create
         // because that variable is on the stack. Instead, we malloc memory.
         // The created thread is responsible for calling free().
-        ushort* remote_fed_id_copy = (ushort*)malloc(sizeof(ushort));
+        uint16_t* remote_fed_id_copy = (uint16_t*)malloc(sizeof(uint16_t));
         if (remote_fed_id_copy == NULL) {
             error_print_and_exit("malloc failed.");
         }
@@ -565,7 +601,7 @@ void _lf_close_outbound_socket(int fed_id) {
  * closed.
  */
 void* listen_for_upstream_messages_from_downstream_federates(void* fed_id_ptr) {
-    ushort fed_id = *((ushort*)fed_id_ptr);
+    uint16_t fed_id = *((uint16_t*)fed_id_ptr);
     unsigned char message;
 
     lf_mutex_lock(&outbound_socket_mutex);
@@ -576,7 +612,7 @@ void* listen_for_upstream_messages_from_downstream_federates(void* fed_id_ptr) {
         lf_mutex_unlock(&outbound_socket_mutex);
 
         DEBUG_PRINT("Thread listening for MSG_TYPE_CLOSE_REQUEST from federate %d", fed_id);
-    	int bytes_read = read_from_socket(
+    	ssize_t bytes_read = read_from_socket(
     			_fed.sockets_for_outbound_p2p_connections[fed_id], 1, &message);
     	// Reacquire the mutex lock before closing or reading the socket again.
         lf_mutex_lock(&outbound_socket_mutex);
@@ -603,14 +639,14 @@ void* listen_for_upstream_messages_from_downstream_federates(void* fed_id_ptr) {
  * refer to the socket for communicating directly with the federate.
  * @param remote_federate_id The ID of the remote federate.
  */
-void connect_to_federate(ushort remote_federate_id) {
+void connect_to_federate(uint16_t remote_federate_id) {
     int result = -1;
     int count_retries = 0;
 
     // Ask the RTI for port number of the remote federate.
     // The buffer is used for both sending and receiving replies.
     // The size is what is needed for receiving replies.
-    unsigned char buffer[sizeof(int) + INET_ADDRSTRLEN];
+    unsigned char buffer[sizeof(int32_t) + INET_ADDRSTRLEN];
     int port = -1;
     struct in_addr host_ip_addr;
     int count_tries = 0;
@@ -621,12 +657,12 @@ void connect_to_federate(ushort remote_federate_id) {
 
         DEBUG_PRINT("Sending address query for federate %d.", remote_federate_id);
 
-        write_to_socket_errexit(_fed.socket_TCP_RTI, sizeof(ushort) + 1, buffer,
+        write_to_socket_errexit(_fed.socket_TCP_RTI, sizeof(uint16_t) + 1, buffer,
                 "Failed to send address query for federate %d to RTI.",
                 remote_federate_id);
 
         // Read RTI's response.
-        read_from_socket_errexit(_fed.socket_TCP_RTI, sizeof(int), buffer,
+        read_from_socket_errexit(_fed.socket_TCP_RTI, sizeof(int32_t), buffer,
                 "Failed to read the requested port number for federate %d from RTI.",
                 remote_federate_id);
 
@@ -655,6 +691,7 @@ void connect_to_federate(ushort remote_federate_id) {
     }
     assert(port < 65536);
     assert(port > 0);
+    uint16_t uport = (uint16_t)port;
 
 #if LOG_LEVEL > 3
     // Print the received IP address in a human readable format
@@ -664,7 +701,7 @@ void connect_to_federate(ushort remote_federate_id) {
     char hostname[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &host_ip_addr, hostname, INET_ADDRSTRLEN);
     LOG_PRINT("Received address %s port %d for federate %d from RTI.",
-            hostname, port, remote_federate_id);
+            hostname, uport, remote_federate_id);
 #endif
 
     // Iterate until we either successfully connect or exceed the number of
@@ -687,14 +724,14 @@ void connect_to_federate(ushort remote_federate_id) {
         server_fd.sin_addr = host_ip_addr; // Received from the RTI
 
         // Convert the port number from host byte order to network byte order.
-        server_fd.sin_port = htons(port);
+        server_fd.sin_port = htons(uport);
         result = connect(
             socket_id,
             (struct sockaddr *)&server_fd,
             sizeof(server_fd));
 
         if (result != 0) {
-            error_print("Failed to connect to federate %d on port %d.", remote_federate_id, port);
+            error_print("Failed to connect to federate %d on port %d.", remote_federate_id, uport);
 
             // Try again after some time if the connection failed.
             // Note that this should not really happen since the remote federate should be
@@ -719,16 +756,16 @@ void connect_to_federate(ushort remote_federate_id) {
             }
         } else {
             // Connect was successful.
-            size_t buffer_length = 1 + sizeof(ushort) + 1;
+            size_t buffer_length = 1 + sizeof(uint16_t) + 1;
             unsigned char buffer[buffer_length];
             buffer[0] = MSG_TYPE_P2P_SENDING_FED_ID;
             if (_lf_my_fed_id > USHRT_MAX) {
                 // This error is very unlikely to occur.
                 error_print_and_exit("Too many federates! More than %d.", USHRT_MAX);
             }
-            encode_uint16((ushort)_lf_my_fed_id, (unsigned char*)&(buffer[1]));
-            unsigned char federation_id_length = strnlen(federation_id, 255);
-            buffer[sizeof(ushort) + 1] = federation_id_length;
+            encode_uint16((uint16_t)_lf_my_fed_id, (unsigned char*)&(buffer[1]));
+            unsigned char federation_id_length = (unsigned char)strnlen(federation_id, 255);
+            buffer[sizeof(uint16_t) + 1] = federation_id_length;
             write_to_socket_errexit(socket_id,
                     buffer_length, buffer,
                     "Failed to send fed_id to federate %d.", remote_federate_id);
@@ -758,7 +795,7 @@ void connect_to_federate(ushort remote_federate_id) {
 
     // Start a thread to listen for upstream messages (MSG_TYPE_CLOSE_REQUEST) from
     // this downstream federate.
-    ushort* remote_fed_id_copy = (ushort*)malloc(sizeof(ushort));
+    uint16_t* remote_fed_id_copy = (uint16_t*)malloc(sizeof(uint16_t));
     if (remote_fed_id_copy == NULL) {
         error_print_and_exit("malloc failed.");
     }
@@ -783,10 +820,21 @@ void connect_to_federate(ushort remote_federate_id) {
  * program exits. If it succeeds, it sets the _fed.socket_TCP_RTI global
  * variable to refer to the socket for communicating with the RTI.
  * @param hostname A hostname, such as "localhost".
- * @param port A port number.
+ * @param port_number A port number.
  */
 void connect_to_rti(char* hostname, int port) {
     LOG_PRINT("Connecting to the RTI.");
+    uint16_t uport = 0;
+    if (port < 0 ||
+            port > INT16_MAX) {
+        error_print(
+            "connect_to_rti(): Specified port (%d) is out of range,"
+            " using zero instead.",
+            port
+        );
+    } else {
+        uport = (uint16_t)port;
+    }
 
     // Repeatedly try to connect, one attempt every 2 seconds, until
     // either the program is killed, the sleep is interrupted,
@@ -794,8 +842,8 @@ void connect_to_rti(char* hostname, int port) {
     // If the specified port is 0, set it instead to the start of the
     // port range.
     bool specific_port_given = true;
-    if (port == 0) {
-        port = STARTING_PORT;
+    if (uport == 0) {
+        uport = STARTING_PORT;
         specific_port_given = false;
     }
     int result = -1;
@@ -821,9 +869,9 @@ void connect_to_rti(char* hostname, int port) {
         server_fd.sin_family = AF_INET;    // IPv4
         bcopy((char*)server->h_addr,
              (char*)&server_fd.sin_addr.s_addr,
-             server->h_length);
+             (size_t)server->h_length);
         // Convert the port number from host byte order to network byte order.
-        server_fd.sin_port = htons(port);
+        server_fd.sin_port = htons(uport);
         result = connect(
             _fed.socket_TCP_RTI,
             (struct sockaddr *)&server_fd,
@@ -831,11 +879,11 @@ void connect_to_rti(char* hostname, int port) {
         // If this failed, try more ports, unless a specific port was given.
         if (result != 0
                 && !specific_port_given
-                && port >= STARTING_PORT
-                && port <= STARTING_PORT + PORT_RANGE_LIMIT
+                && uport >= STARTING_PORT
+                && uport <= STARTING_PORT + PORT_RANGE_LIMIT
         ) {
-            info_print("Failed to connect to RTI on port %d. Trying %d.", port, port + 1);
-            port++;
+            info_print("Failed to connect to RTI on port %d. Trying %d.", uport, uport + 1);
+            uport++;
             // Wait PORT_KNOCKING_RETRY_INTERVAL seconds.
             struct timespec wait_time = {0L, PORT_KNOCKING_RETRY_INTERVAL};
             struct timespec remaining_time;
@@ -846,8 +894,8 @@ void connect_to_rti(char* hostname, int port) {
         }
         // If this still failed, try again with the original port after some time.
         if (result < 0) {
-            if (!specific_port_given && port == STARTING_PORT + PORT_RANGE_LIMIT + 1) {
-                port = STARTING_PORT;
+            if (!specific_port_given && uport == STARTING_PORT + PORT_RANGE_LIMIT + 1) {
+                uport = STARTING_PORT;
             }
             count_retries++;
             if (count_retries > CONNECT_NUM_RETRIES) {
@@ -877,13 +925,13 @@ void connect_to_rti(char* hostname, int port) {
             if (_lf_my_fed_id > USHRT_MAX) {
                 error_print_and_exit("Too many federates! More than %d.", USHRT_MAX);
             }
-            encode_uint16((ushort)_lf_my_fed_id, &buffer[1]);
+            encode_uint16((uint16_t)_lf_my_fed_id, &buffer[1]);
             // Next send the federation ID length.
             // The federation ID is limited to 255 bytes.
             size_t federation_id_length = strnlen(federation_id, 255);
-            buffer[1 + sizeof(ushort)] = (unsigned char)(federation_id_length & 0xff);
+            buffer[1 + sizeof(uint16_t)] = (unsigned char)(federation_id_length & 0xff);
 
-            write_to_socket_errexit(_fed.socket_TCP_RTI, 2 + sizeof(ushort), buffer,
+            write_to_socket_errexit(_fed.socket_TCP_RTI, 2 + sizeof(uint16_t), buffer,
                     "Failed to send federate ID to RTI.");
 
             // Next send the federation ID itself.
@@ -904,8 +952,8 @@ void connect_to_rti(char* hostname, int port) {
                 unsigned char cause;
                 read_from_socket_errexit(_fed.socket_TCP_RTI, 1, &cause, "Failed to read the cause of rejection by the RTI.");
                 if (cause == FEDERATION_ID_DOES_NOT_MATCH || cause == WRONG_SERVER) {
-                    info_print("Connected to the wrong RTI on port %d. Trying %d.", port, port + 1);
-                    port++;
+                    info_print("Connected to the wrong RTI on port %d. Trying %d.", uport, uport + 1);
+                    uport++;
                     result = -1;
                     continue;
                 }
@@ -913,19 +961,19 @@ void connect_to_rti(char* hostname, int port) {
                         "%d. Error code: %d. Federate quits.\n", response, cause);
             } else if (response == MSG_TYPE_ACK) {
                 LOG_PRINT("Received acknowledgment from the RTI.");
-                ushort udp_port = setup_clock_synchronization_with_rti();
+                uint16_t udp_port = setup_clock_synchronization_with_rti();
 
                 // Write the returned port number to the RTI
-                unsigned char UDP_port_number[1 + sizeof(ushort)];
+                unsigned char UDP_port_number[1 + sizeof(uint16_t)];
                 UDP_port_number[0] = MSG_TYPE_UDP_PORT;
                 encode_uint16(udp_port, &(UDP_port_number[1]));
-                write_to_socket_errexit(_fed.socket_TCP_RTI, 1 + sizeof(ushort), UDP_port_number,
+                write_to_socket_errexit(_fed.socket_TCP_RTI, 1 + sizeof(uint16_t), UDP_port_number,
                             "Failed to send the UDP port number to the RTI.");
             } else {
                 error_print_and_exit("Received unexpected response %u from the RTI (see rti.h).",
                         response);
             }
-            info_print("Connected to RTI at %s:%d.", hostname, port);
+            info_print("Connected to RTI at %s:%d.", hostname, uport);
         }
     }
 }
@@ -945,7 +993,7 @@ instant_t get_start_time_from_rti(instant_t my_physical_time) {
 
     // Read bytes from the socket. We need 9 bytes.
     // Buffer for message ID plus timestamp.
-    int buffer_length = sizeof(instant_t) + 1;
+    size_t buffer_length = 1 + sizeof(instant_t);
     unsigned char buffer[buffer_length];
 
     read_from_socket_errexit(_fed.socket_TCP_RTI, buffer_length, buffer,
@@ -1220,7 +1268,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
                                     unsigned short port_ID, 
                                   unsigned short fed_ID) {
     // Construct the message
-    int message_length = 1 + sizeof(port_ID) + sizeof(fed_ID) + sizeof(instant_t) + sizeof(microstep_t);
+    size_t message_length = 1 + sizeof(port_ID) + sizeof(fed_ID) + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[message_length];
 
     // Apply the additional delay to the current tag and use that as the intended
@@ -1237,9 +1285,8 @@ void send_port_absent_to_federate(interval_t additional_delay,
     buffer[0] = MSG_TYPE_PORT_ABSENT;
     encode_uint16(port_ID, &(buffer[1]));
     encode_uint16(fed_ID, &(buffer[1+sizeof(port_ID)]));
-    encode_int64(current_message_intended_tag.time, &(buffer[1+sizeof(port_ID)+sizeof(fed_ID)]));
-    encode_int32(current_message_intended_tag.microstep, &(buffer[1+sizeof(port_ID)+sizeof(fed_ID)+sizeof(instant_t)]));
-
+    encode_tag(&(buffer[1+sizeof(port_ID)+sizeof(fed_ID)]), current_message_intended_tag);
+    
     lf_mutex_lock(&outbound_socket_mutex);
 #ifdef FEDERATED_CENTRALIZED
     // Send the absent message through the RTI
@@ -1440,7 +1487,7 @@ int _lf_request_close_inbound_socket(int fed_id) {
    	// Send a MSG_TYPE_CLOSE_REQUEST message.
     unsigned char message_marker = MSG_TYPE_CLOSE_REQUEST;
    	LOG_PRINT("Sending MSG_TYPE_CLOSE_REQUEST message to upstream federate.");
-    int written = write_to_socket(
+    ssize_t written = write_to_socket(
      		_fed.sockets_for_inbound_p2p_connections[fed_id],
 			1, &message_marker);
     _fed.sockets_for_inbound_p2p_connections[fed_id] = -1;
@@ -1488,7 +1535,7 @@ void _lf_close_inbound_socket(int fed_id) {
  * @param fed_id The sending federate ID or -1 if the centralized coordination.
  */
 void handle_port_absent_message(int socket, int fed_id) {
-    size_t bytes_to_read = sizeof(ushort) + sizeof(ushort) + sizeof(instant_t) + sizeof(microstep_t);
+    size_t bytes_to_read = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(socket, bytes_to_read, buffer,
     		"Failed to read port absent message.");
@@ -1496,9 +1543,8 @@ void handle_port_absent_message(int socket, int fed_id) {
     // Extract the header information.
     unsigned short port_id = extract_uint16(buffer);
     // The next part of the message is the federate_id, but we don't need it.
-    // unsigned short federate_id = extract_uint16(&(buffer[sizeof(ushort)]));
-    tag_t intended_tag;
-    extract_tag(&(buffer[sizeof(ushort)+sizeof(ushort)]), &intended_tag.time, &intended_tag.microstep);
+    // unsigned short federate_id = extract_uint16(&(buffer[sizeof(uint16_t)]));
+    tag_t intended_tag = extract_tag(&(buffer[sizeof(uint16_t)+sizeof(uint16_t)]));
 
     LOG_PRINT("Handling port absent for tag (%lld, %u) for port %d.",
             intended_tag.time - start_time,
@@ -1540,7 +1586,7 @@ void handle_port_absent_message(int socket, int fed_id) {
 void handle_message(int socket, int fed_id) {
     // FIXME: Need better error handling?
     // Read the header.
-    size_t bytes_to_read = sizeof(ushort) + sizeof(ushort) + sizeof(int);
+    size_t bytes_to_read = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(socket, bytes_to_read, buffer,
     		"Failed to read message header.");
@@ -1588,7 +1634,7 @@ void handle_message(int socket, int fed_id) {
 void handle_tagged_message(int socket, int fed_id) {
     // FIXME: Need better error handling?
     // Read the header which contains the timestamp.
-    size_t bytes_to_read = sizeof(ushort) + sizeof(ushort) + sizeof(int)
+    size_t bytes_to_read = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t)
             + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(socket, bytes_to_read, buffer,
@@ -1757,12 +1803,11 @@ void handle_tagged_message(int socket, int fed_id) {
  *  it sets last_TAG_was_provisional to false.
  */
 void handle_tag_advance_grant() {
-    int bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
+    size_t bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read tag advance grant from RTI.");
-    tag_t TAG;
-    extract_tag(buffer, &TAG.time, &TAG.microstep);
+    tag_t TAG = extract_tag(buffer);
 
     lf_mutex_lock(&mutex);
 
@@ -1834,12 +1879,11 @@ void _lf_logical_tag_complete(tag_t tag_to_send) {
  *  last known tag for input ports.
  */
 void handle_provisional_tag_advance_grant() {
-    int bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
+    size_t bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];    
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read provisional tag advance grant from RTI.");
-    tag_t PTAG;
-    extract_tag(buffer, &PTAG.time, &PTAG.microstep);
+    tag_t PTAG = extract_tag(buffer);
 
     // Note: it is important that last_known_status_tag of ports does not
     // get updated to a PTAG value because a PTAG does not indicate that
@@ -1973,7 +2017,7 @@ void _lf_fd_send_stop_request_to_rti() {
  * the mutex lock, therefore, it acquires it.
  */
 void handle_stop_granted_message() {
-    int bytes_to_read = MSG_TYPE_STOP_GRANTED_LENGTH - 1;
+    size_t bytes_to_read = MSG_TYPE_STOP_GRANTED_LENGTH - 1;
     unsigned char buffer[bytes_to_read];    
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read stop granted from RTI.");
@@ -1982,8 +2026,7 @@ void handle_stop_granted_message() {
     // message is transport or being used to determine a TAG.
     lf_mutex_lock(&mutex);
 
-    tag_t received_stop_tag;
-    extract_tag(buffer, &received_stop_tag.time, &received_stop_tag.microstep);
+    tag_t received_stop_tag = extract_tag(buffer);
 
     LOG_PRINT("Received from RTI a MSG_TYPE_STOP_GRANTED message with elapsed tag (%lld, %d).",
             received_stop_tag.time - start_time, received_stop_tag.microstep);
@@ -2020,7 +2063,7 @@ void handle_stop_granted_message() {
  * the mutex lock, therefore, it acquires it.
  */
 void handle_stop_request_message() {
-    int bytes_to_read = MSG_TYPE_STOP_REQUEST_LENGTH - 1;
+    size_t bytes_to_read = MSG_TYPE_STOP_REQUEST_LENGTH - 1;
     unsigned char buffer[bytes_to_read];    
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
     		"Failed to read stop request from RTI.");
@@ -2035,8 +2078,7 @@ void handle_stop_request_message() {
         return;
     }
 
-    tag_t tag_to_stop;
-    extract_tag(buffer, &tag_to_stop.time, &tag_to_stop.microstep);
+    tag_t tag_to_stop = extract_tag(buffer);
 
     LOG_PRINT("Received from RTI a MSG_TYPE_STOP_REQUEST message with tag (%lld, %u).",
              tag_to_stop.time - start_time,
@@ -2102,7 +2144,7 @@ void terminate_execution() {
     // Resign the federation, which will close the socket to the RTI.
    	if (_fed.socket_TCP_RTI >= 0) {
         unsigned char message_marker = MSG_TYPE_RESIGN;
-        int written = write_to_socket(_fed.socket_TCP_RTI, 1, &message_marker);
+        ssize_t written = write_to_socket(_fed.socket_TCP_RTI, 1, &message_marker);
         if (written == 1) {
         	LOG_PRINT("Resigned.");
         }
@@ -2142,12 +2184,12 @@ void terminate_execution() {
  * from the peer, then this procedure sets the corresponding 
  * socket in _fed.sockets_for_inbound_p2p_connections
  * to -1 and returns, terminating the thread.
- * @param fed_id_ptr A pointer to a ushort containing federate ID being listened to.
+ * @param fed_id_ptr A pointer to a uint16_t containing federate ID being listened to.
  *  This procedure frees the memory pointed to before returning.
  */
 void* listen_to_federates(void* fed_id_ptr) {
 
-    ushort fed_id = *((ushort*)fed_id_ptr);
+    uint16_t fed_id = *((uint16_t*)fed_id_ptr);
 
     LOG_PRINT("Listening to federate %d.", fed_id);
 
@@ -2162,7 +2204,7 @@ void* listen_to_federates(void* fed_id_ptr) {
     while (1) {
         // Read one byte to get the message type.
         DEBUG_PRINT("Waiting for a P2P message on socket %d.", socket_id);
-        int bytes_read = read_from_socket(socket_id, 1, buffer);
+        ssize_t bytes_read = read_from_socket(socket_id, 1, buffer);
         if (bytes_read == 0) {
             // EOF occurred. This breaks the connection.
             info_print("Received EOF from peer federate %d. Closing the socket.", fed_id);
@@ -2221,7 +2263,7 @@ void* listen_to_rti_TCP(void* args) {
         }
         // Read one byte to get the message type.
         // This will exit if the read fails.
-        int bytes_read = read_from_socket(_fed.socket_TCP_RTI, 1, buffer);
+        ssize_t bytes_read = read_from_socket(_fed.socket_TCP_RTI, 1, buffer);
         if (bytes_read < 0) {
             if (errno == ECONNRESET) {
                 error_print("Socket connection to the RTI was closed by the RTI without"

--- a/org.lflang/src/lib/core/federate.h
+++ b/org.lflang/src/lib/core/federate.h
@@ -57,7 +57,7 @@ typedef struct federate_instance_t {
 	 * This can be either physical connections, or logical connections
 	 * in the decentralized coordination, or both.
 	 */
-	int number_of_inbound_p2p_connections;
+	size_t number_of_inbound_p2p_connections;
 
 	/**
 	 * Array of thread IDs for threads that listen for incoming messages.
@@ -71,7 +71,7 @@ typedef struct federate_instance_t {
 	 * This can be either physical connections, or logical connections
 	 * in the decentralized coordination, or both.
 	 */
-	int number_of_outbound_p2p_connections;
+	size_t number_of_outbound_p2p_connections;
 
 	/**
 	 * An array that holds the socket descriptors for inbound
@@ -215,7 +215,7 @@ typedef struct federate_instance_t {
 	 * to trigger these reaction at the beginning of every tag.
 	 */
 	trigger_t** triggers_for_network_input_control_reactions;
-	int triggers_for_network_input_control_reactions_size;
+	size_t triggers_for_network_input_control_reactions_size;
 
 
 	/**

--- a/org.lflang/src/lib/core/net_util.c
+++ b/org.lflang/src/lib/core/net_util.c
@@ -281,7 +281,7 @@ void encode_int32(int32_t data, unsigned char* buffer) {
  */
 void encode_uint32(uint32_t data, unsigned char* buffer) {
     // This strategy is fairly brute force, but it avoids potential
-    // alignment problems.  Note that this assumes an int32_t is four bytes.
+    // alignment problems.  Note that this assumes a uint32_t is four bytes.
     buffer[0] = (unsigned char)(data & 0xff);
     buffer[1] = (unsigned char)((data & 0xff00) >> 8);
     buffer[2] = (unsigned char)((data & 0xff0000) >> 16);
@@ -338,7 +338,7 @@ int32_t swap_bytes_if_big_endian_int32(int32_t src) {
  *  meaning that the low-order byte is first in memory.
  *  @param src The argument to convert.
  */
-uint32_t swap_bytes_if_big_endian_uint32(int32_t src) {
+uint32_t swap_bytes_if_big_endian_uint32(uint32_t src) {
     union {
         uint32_t uint;
         unsigned char c[sizeof(uint32_t)];
@@ -526,7 +526,11 @@ void extract_timed_header(
 ) {
 	extract_header(buffer, port_id, federate_id, length);
 
-    *tag = extract_tag(&(buffer[sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t)]));
+    tag_t temporary_tag = extract_tag(
+        &(buffer[sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t)])
+    );
+    tag->time = temporary_tag.time;
+    tag->microstep = temporary_tag.microstep;
 }
 
 /**
@@ -544,7 +548,7 @@ tag_t extract_tag(
     tag_t tag;
     tag.time = extract_int64(buffer);
     tag.microstep = extract_uint32(&(buffer[sizeof(int64_t)]));
-        
+
     return tag;
 }
 
@@ -558,7 +562,7 @@ tag_t extract_tag(
  */
 void encode_tag(
     unsigned char* buffer,
-	tag_t tag
+    tag_t tag
 ){
     encode_int64(tag.time, buffer);
     encode_uint32(tag.microstep, &(buffer[sizeof(int64_t)]));  

--- a/org.lflang/src/lib/core/net_util.h
+++ b/org.lflang/src/lib/core/net_util.h
@@ -151,7 +151,7 @@ int write_to_socket2(int socket, int num_bytes, unsigned char* buffer);
  *  @param data The data to write.
  *  @param buffer The location to start writing.
  */
-void encode_ll(long long data, unsigned char* buffer);
+void encode_int64(int64_t data, unsigned char* buffer);
 
 /** Write the specified data as a sequence of bytes starting
  *  at the specified address. This encodes the data in little-endian
@@ -160,7 +160,7 @@ void encode_ll(long long data, unsigned char* buffer);
  *  @param data The data to write.
  *  @param buffer The location to start writing.
  */
-void encode_int(int data, unsigned char* buffer);
+void encode_int32(int32_t data, unsigned char* buffer);
 
 /** Write the specified data as a sequence of bytes starting
  *  at the specified address. This encodes the data in little-endian
@@ -168,7 +168,7 @@ void encode_int(int data, unsigned char* buffer);
  *  @param data The data to write.
  *  @param buffer The location to start writing.
  */
-void encode_ushort(unsigned short data, unsigned char* buffer);
+void encode_uint16(uint16_t data, unsigned char* buffer);
 
 /** If this host is little endian, then reverse the order of
  *  the bytes of the argument. Otherwise, return the argument
@@ -180,7 +180,7 @@ void encode_ushort(unsigned short data, unsigned char* buffer);
  *  meaning that the low-order byte is first in memory.
  *  @param src The argument to convert.
  */
-int swap_bytes_if_big_endian_int(int src);
+int32_t swap_bytes_if_big_endian_int32(int32_t src);
 
 /** If this host is little endian, then reverse the order of
  *  the bytes of the argument. Otherwise, return the argument
@@ -192,7 +192,7 @@ int swap_bytes_if_big_endian_int(int src);
  *  meaning that the low-order byte is first in memory.
  *  @param src The argument to convert.
  */
-long long swap_bytes_if_big_endian_ll(long long src);
+int64_t swap_bytes_if_big_endian_int64(int64_t src);
 
 /** If this host is little endian, then reverse the order of
  *  the bytes of the argument. Otherwise, return the argument
@@ -204,25 +204,25 @@ long long swap_bytes_if_big_endian_ll(long long src);
  *  meaning that the low-order byte is first in memory.
  *  @param src The argument to convert.
  */
-int swap_bytes_if_big_endian_ushort(unsigned short src);
+uint16_t swap_bytes_if_big_endian_uint16(uint16_t src);
 
-/** Extract an int from the specified byte sequence.
+/** Extract an int32_t from the specified byte sequence.
  *  This will swap the order of the bytes if this machine is big endian.
  *  @param bytes The address of the start of the sequence of bytes.
  */
-int extract_int(unsigned char* bytes);
+int32_t extract_int32(unsigned char* bytes);
 
-/** Extract a long long from the specified byte sequence.
+/** Extract a int64_t from the specified byte sequence.
  *  This will swap the order of the bytes if this machine is big endian.
  *  @param bytes The address of the start of the sequence of bytes.
  */
-long long extract_ll(unsigned char* bytes);
+int64_t extract_int64(unsigned char* bytes);
 
-/** Extract an unsigned short from the specified byte sequence.
+/** Extract an uint16_t from the specified byte sequence.
  *  This will swap the order of the bytes if this machine is big endian.
  *  @param bytes The address of the start of the sequence of bytes.
  */
-unsigned short extract_ushort(unsigned char* bytes);
+uint16_t extract_uint16(unsigned char* bytes);
 
 /**
  * Extract the core header information that all messages between
@@ -236,9 +236,9 @@ unsigned short extract_ushort(unsigned char* bytes);
  */
 void extract_header(
         unsigned char* buffer,
-        unsigned short* port_id,
-        unsigned short* federate_id,
-        unsigned int* length
+        uint16_t* port_id,
+        uint16_t* federate_id,
+        uint32_t* length
 );
 
 /**
@@ -255,9 +255,9 @@ void extract_header(
  */
 void extract_timed_header(
         unsigned char* buffer,
-        unsigned short* port_id,
-        unsigned short* federate_id,
-        unsigned int* length,
+        uint16_t* port_id,
+        uint16_t* federate_id,
+        uint32_t* length,
 		tag_t* tag
 );
 

--- a/org.lflang/src/lib/core/net_util.h
+++ b/org.lflang/src/lib/core/net_util.h
@@ -155,12 +155,19 @@ void encode_int64(int64_t data, unsigned char* buffer);
 
 /** Write the specified data as a sequence of bytes starting
  *  at the specified address. This encodes the data in little-endian
- *  order (lowest order byte first). This works for either int or
- *  unsigned int.
+ *  order (lowest order byte first). This works for int32_t.
  *  @param data The data to write.
  *  @param buffer The location to start writing.
  */
 void encode_int32(int32_t data, unsigned char* buffer);
+
+/** Write the specified data as a sequence of bytes starting
+ *  at the specified address. This encodes the data in little-endian
+ *  order (lowest order byte first). This works for uint32_t.
+ *  @param data The data to write.
+ *  @param buffer The location to start writing.
+ */
+void encode_uint32(uint32_t data, unsigned char* buffer);
 
 /** Write the specified data as a sequence of bytes starting
  *  at the specified address. This encodes the data in little-endian
@@ -268,13 +275,23 @@ void extract_timed_header(
  * 32-bit (4 byte) unsigned integer for microstep.
  * 
  * @param buffer The buffer to read from.
- * @param time Will be populated after reading from the buffer.
- * @param microstep Will be populated after reading from the buffer.
+ * @return The extracted tag.
  */
-void extract_tag(
-        unsigned char* buffer,
-        int64_t* time,
-        uint32_t* microstep
+tag_t extract_tag(
+	unsigned char* buffer
+);
+
+/**
+ * Encode tag information into buffer.
+ * 
+ * Buffer must have been allocated externally.
+ * 
+ * @param buffer The buffer to encode into.
+ * @param tag The tag to encode into 'buffer'.
+ */
+void encode_tag(
+    unsigned char* buffer,
+	tag_t tag
 );
 
 #endif /* NET_UTIL_H */

--- a/org.lflang/src/lib/core/net_util.h
+++ b/org.lflang/src/lib/core/net_util.h
@@ -65,9 +65,9 @@ int host_is_big_endian();
  * @return The number of bytes read, or 0 if an EOF is received, or
  *  a negative number for an error.
  */
-int read_from_socket_errexit(
+ssize_t read_from_socket_errexit(
 		int socket,
-		int num_bytes,
+		size_t num_bytes,
 		unsigned char* buffer,
 		char* format, ...);
 
@@ -82,7 +82,7 @@ int read_from_socket_errexit(
  * @param buffer The buffer into which to put the bytes.
  * @return The number of bytes read or 0 when EOF is received or negative for an error.
  */
-int read_from_socket(int socket, int num_bytes, unsigned char* buffer);
+ssize_t read_from_socket(int socket, size_t num_bytes, unsigned char* buffer);
 
 /**
  * Write the specified number of bytes to the specified socket from the
@@ -101,9 +101,9 @@ int read_from_socket(int socket, int num_bytes, unsigned char* buffer);
  * @return The number of bytes written, or 0 if an EOF was received, or a negative
  *  number if an error occurred.
  */
-int write_to_socket_errexit_with_mutex(
+ssize_t write_to_socket_errexit_with_mutex(
 		int socket,
-		int num_bytes,
+		size_t num_bytes,
 		unsigned char* buffer,
 		lf_mutex_t* mutex,
 		char* format, ...);
@@ -125,9 +125,9 @@ int write_to_socket_errexit_with_mutex(
  * @return The number of bytes written, or 0 if an EOF was received, or a negative
  *  number if an error occurred.
  */
-int write_to_socket_errexit(
+ssize_t write_to_socket_errexit(
 		int socket,
-		int num_bytes,
+		size_t num_bytes,
 		unsigned char* buffer,
 		char* format, ...);
 
@@ -238,7 +238,7 @@ void extract_header(
         unsigned char* buffer,
         uint16_t* port_id,
         uint16_t* federate_id,
-        uint32_t* length
+        size_t* length
 );
 
 /**
@@ -257,8 +257,24 @@ void extract_timed_header(
         unsigned char* buffer,
         uint16_t* port_id,
         uint16_t* federate_id,
-        uint32_t* length,
+        size_t* length,
 		tag_t* tag
+);
+
+/**
+ * Extract tag information from buffer.
+ *
+ * The tag is transmitted as a 64-bit (8 byte) signed integer for time and a
+ * 32-bit (4 byte) unsigned integer for microstep.
+ * 
+ * @param buffer The buffer to read from.
+ * @param time Will be populated after reading from the buffer.
+ * @param microstep Will be populated after reading from the buffer.
+ */
+void extract_tag(
+        unsigned char* buffer,
+        int64_t* time,
+        uint32_t* microstep
 );
 
 #endif /* NET_UTIL_H */

--- a/org.lflang/src/lib/core/platform.h
+++ b/org.lflang/src/lib/core/platform.h
@@ -72,8 +72,6 @@ typedef _lf_cond_t lf_cond_t;            // Type to hold handle to a condition v
 typedef _lf_thread_t lf_thread_t;        // Type to hold handle to a thread
 #endif
 
-typedef _lf_clock_t lf_clock_t;          // Type to hold a clock identifier (e.g., CLOCK_REALTIME on POSIX)
-
 /**
  * Time instant. Both physical and logical times are represented
  * using this typedef.

--- a/org.lflang/src/lib/core/platform/lf_C11_threads_support.c
+++ b/org.lflang/src/lib/core/platform/lf_C11_threads_support.c
@@ -31,6 +31,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "lf_C11_threads_support.h"
 #include <stdlib.h>
+#include <stdint.h> // For fixed-width integral types
 
 /**
  * Create a new thread, starting with execution of lf_thread
@@ -128,7 +129,7 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
  * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
  *  number otherwise (see pthread_cond_timedwait).
  */
-int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, long long absolute_time_ns) {
+int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, int64_t absolute_time_ns) {
     // Convert the absolute time to a timespec.
     // timespec is seconds and nanoseconds.
     struct timespec timespec_absolute_time

--- a/org.lflang/src/lib/core/platform/lf_POSIX_threads_support.c
+++ b/org.lflang/src/lib/core/platform/lf_POSIX_threads_support.c
@@ -32,7 +32,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "lf_POSIX_threads_support.h"
-#include "errno.h"
+#include <errno.h>
+#include <stdint.h> // For fixed-width integral types
 
 /**
  * Create a new thread, starting with execution of lf_thread getting passed
@@ -135,7 +136,7 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_mutex_t* mutex) {
  * @return 0 on success, LF_TIMEOUT on timeout, and platform-specific error
  *  number otherwise (see pthread_cond_timedwait).
  */
-int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, long long absolute_time_ns) {
+int lf_cond_timedwait(_lf_cond_t* cond, _lf_mutex_t* mutex, int64_t absolute_time_ns) {
     // Convert the absolute time to a timespec.
     // timespec is seconds and nanoseconds.
     struct timespec timespec_absolute_time

--- a/org.lflang/src/lib/core/platform/lf_linux_support.h
+++ b/org.lflang/src/lib/core/platform/lf_linux_support.h
@@ -40,7 +40,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-typedef int _lf_clock_t;
+#include <stdint.h> // For fixed-width integral types
 
 /**
  * Time instant. Both physical and logical times are represented
@@ -48,17 +48,17 @@ typedef int _lf_clock_t;
  * WARNING: If this code is used after about the year 2262,
  * then representing time as a 64-bit long long will be insufficient.
  */
-typedef long long _instant_t;
+typedef int64_t _instant_t;
 
 /**
  * Interval of time.
  */
-typedef long long _interval_t;
+typedef int64_t _interval_t;
 
 /**
  * Microstep instant.
  */
-typedef unsigned int _microstep_t;
+typedef uint32_t _microstep_t;
 
 
 // The underlying physical clock for Linux

--- a/org.lflang/src/lib/core/platform/lf_macos_support.h
+++ b/org.lflang/src/lib/core/platform/lf_macos_support.h
@@ -40,7 +40,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-typedef int _lf_clock_t;
+#include <stdint.h> // For fixed-width integral types
 
 /**
  * Time instant. Both physical and logical times are represented
@@ -48,17 +48,17 @@ typedef int _lf_clock_t;
  * WARNING: If this code is used after about the year 2262,
  * then representing time as a 64-bit long long will be insufficient.
  */
-typedef long long _instant_t;
+typedef int64_t _instant_t;
 
 /**
  * Interval of time.
  */
-typedef long long _interval_t;
+typedef int64_t _interval_t;
 
 /**
  * Microstep instant.
  */
-typedef unsigned int _microstep_t;
+typedef uint32_t _microstep_t;
 
 // The underlying physical clock for MacOS
 #define _LF_CLOCK CLOCK_MONOTONIC

--- a/org.lflang/src/lib/core/platform/lf_windows_support.h
+++ b/org.lflang/src/lib/core/platform/lf_windows_support.h
@@ -38,6 +38,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <windows.h>
 #include <process.h>
+#include <stdint.h> // For fixed-width integral types
 
 #ifdef NUMBER_OF_WORKERS
 #if __STDC_VERSION__ < 201112L || defined (__STDC_NO_THREADS__) // (Not C++11 or later) or no threads support
@@ -63,25 +64,23 @@ typedef HANDLE _lf_thread_t;
 #endif
 #endif
 
-typedef int _lf_clock_t;
-
 /**
  * Time instant. Both physical and logical times are represented
  * using this typedef.
  * WARNING: If this code is used after about the year 2262,
  * then representing time as a 64-bit long long will be insufficient.
  */
-typedef long long _instant_t;
+typedef int64_t _instant_t;
 
 /**
  * Interval of time.
  */
-typedef long long _interval_t;
+typedef int64_t _interval_t;
 
 /**
  * Microstep instant.
  */
-typedef unsigned int _microstep_t;
+typedef uint32_t _microstep_t;
 
 #define _LF_TIMEOUT ETIMEDOUT
 

--- a/org.lflang/src/lib/core/reactor.c
+++ b/org.lflang/src/lib/core/reactor.c
@@ -61,7 +61,7 @@ handle_t _lf_schedule_token(void* action, interval_t extra_delay, lf_token_t* to
  * Variant of schedule_token that creates a token to carry the specified value.
  * See reactor.h for documentation.
  */
-handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, int length) {
+handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, size_t length) {
     trigger_t* trigger = _lf_action_to_trigger(action);
     lf_token_t* token = create_token(trigger->element_size);
     token->value = value;
@@ -74,7 +74,7 @@ handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, i
  * with a copy of the specified value.
  * See reactor.h for documentation.
  */
-handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, int length) {
+handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, size_t length) {
     trigger_t* trigger = _lf_action_to_trigger(action);
     if (value == NULL) {
         return schedule_token(action, offset, NULL);

--- a/org.lflang/src/lib/core/reactor.h
+++ b/org.lflang/src/lib/core/reactor.h
@@ -396,7 +396,7 @@ typedef struct lf_token_t {
     /** Size of the struct or array element. */
     size_t element_size;
     /** Length of the array or 1 for a struct. */
-    int length;
+    size_t length;
     /** The number of input ports that have not already reacted to the message. */
     int ref_count;
     /**
@@ -733,7 +733,7 @@ handle_t _lf_schedule_token(void* action, interval_t extra_delay, lf_token_t* to
  * Variant of schedule_token that creates a token to carry the specified value.
  * The value is required to be malloc'd memory with a size equal to the
  * element_size of the specifies action times the length parameter.
- * See schedule_token() for details.
+ * See _lf_schedule_token() for details.
  * @param action The action to be triggered.
  * @param extra_delay Extra offset of the event release above that in the action.
  * @param value Dynamically allocated memory containing the value to send.
@@ -741,7 +741,7 @@ handle_t _lf_schedule_token(void* action, interval_t extra_delay, lf_token_t* to
  *  scalar and 0 for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, int length);
+handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, size_t length);
 
 /**
  * Schedule an action to occur with the specified value and time offset
@@ -749,14 +749,14 @@ handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, i
  * then it will be copied into newly allocated memory under the assumption
  * that its size is given in the trigger's token object's element_size field
  * multiplied by the specified length.
- * See schedule_token(), which this uses, for details.
+ * See _lf_schedule_token(), which this uses, for details.
  * @param action Pointer to an action on a self struct.
  * @param offset The time offset over and above that in the action.
  * @param value A pointer to the value to copy.
  * @param length The length, if an array, 1 if a scalar, and 0 if value is NULL.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, int length);
+handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, size_t length);
 
 /**
  * For a federated execution, send a STOP_REQUEST message

--- a/org.lflang/src/lib/core/reactor.h
+++ b/org.lflang/src/lib/core/reactor.h
@@ -438,7 +438,7 @@ struct reaction_t {
     unsigned long long chain_id; // Binary encoding of the branches that this reaction has upstream in the dependency graph. INSTANCE.
     size_t pos;       // Current position in the priority queue. RUNTIME.
     reaction_t* last_enabling_reaction; // The last enabling reaction, or NULL if there is none. Used for optimization. INSTANCE.
-    int num_outputs;  // Number of outputs that may possibly be produced by this function. COMMON.
+    size_t num_outputs;  // Number of outputs that may possibly be produced by this function. COMMON.
     bool** output_produced;   // Array of pointers to booleans indicating whether outputs were produced. COMMON.
     int* triggered_sizes;     // Pointer to array of ints with number of triggers per output. INSTANCE.
     trigger_t ***triggers;    // Array of pointers to arrays of pointers to triggers triggered by each output. INSTANCE.

--- a/org.lflang/src/lib/core/reactor_common.c
+++ b/org.lflang/src/lib/core/reactor_common.c
@@ -1698,90 +1698,91 @@ int process_args(int argc, char* argv[]) {
             } else {
                 error_print("Invalid value for --fast: %s", fast_spec);
             }
-       } else if (strcmp(argv[i], "-o") == 0
-               || strcmp(argv[i], "--timeout") == 0
-               || strcmp(argv[i], "-timeout") == 0) {
-           // Tolerate -timeout for legacy uses.
-           if (argc < i + 3) {
-               error_print("--timeout needs time and units.");
-               usage(argc, argv);
-               return 0;
-           }
-           i++;
-           char* time_spec = argv[i++];
-           char* units = argv[i];
-           duration = atoll(time_spec);
-           // A parse error returns 0LL, so check to see whether that is what is meant.
-           if (duration == 0LL && strncmp(time_spec, "0", 1) != 0) {
-        	   // Parse error.
-               error_print("Invalid time value: %s", time_spec);
-        	   usage(argc, argv);
-        	   return 0;
-           }
-           if (strncmp(units, "sec", 3) == 0) {
-        	   duration = SEC(duration);
-           } else if (strncmp(units, "msec", 4) == 0) {
-        	   duration = MSEC(duration);
-           } else if (strncmp(units, "usec", 4) == 0) {
-        	   duration = USEC(duration);
-           } else if (strncmp(units, "nsec", 4) == 0) {
-        	   duration = NSEC(duration);
-           } else if (strncmp(units, "min", 3) == 0) {
-        	   duration = MINUTE(duration);
-           } else if (strncmp(units, "hour", 4) == 0) {
-        	   duration = HOUR(duration);
-           } else if (strncmp(units, "day", 3) == 0) {
-        	   duration = DAY(duration);
-           } else if (strncmp(units, "week", 4) == 0) {
-        	   duration = WEEK(duration);
-           } else {
-        	   // Invalid units.
-               error_print("Invalid time units: %s", units);
-        	   usage(argc, argv);
-        	   return 0;
-           }
-       } else if (strcmp(argv[i], "-k") == 0 || strcmp(argv[i], "--keepalive") == 0) {
-    	   if (argc < i + 2) {
-    	       error_print("--keepalive needs a boolean.");
-    		   usage(argc, argv);
-    		   return 0;
-    	   }
-    	   i++;
-    	   char* keep_spec = argv[i];
-    	   if (strcmp(keep_spec, "true") == 0) {
-    		   keepalive_specified = true;
-    	   } else if (strcmp(keep_spec, "false") == 0) {
-    		   keepalive_specified = false;
-    	   } else {
-    	       error_print("Invalid value for --keepalive: %s", keep_spec);
-    	   }
-       } else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--threads") == 0) {
-    	   if (argc < i + 2) {
-    	       error_print("--threads needs an integer argument.s");
-    		   usage(argc, argv);
-    		   return 0;
-    	   }
-    	   i++;
-    	   char* threads_spec = argv[i++];
-    	   int num_threads = atoi(threads_spec);
-    	   if (num_threads <= 0) {
-    	       error_print("Invalid value for --threads: %s", threads_spec);
-    	   }
-           _lf_number_of_threads = (unsigned int)num_threads;
-       } else if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--id") == 0) {
-           if (argc < i + 2) {
-               error_print("--id needs a string argument.");
-               usage(argc, argv);
-               return 0;
-           }
-           i++;
-           info_print("Federation ID for executable %s: %s", argv[0], argv[i]);
-           federation_id = argv[i++];
-       } else {
-           error_print("Unrecognized command-line argument: %s", argv[i]);
-    	   usage(argc, argv);
-    	   return 0;
-       }
+        } else if (strcmp(argv[i], "-o") == 0
+                || strcmp(argv[i], "--timeout") == 0
+                || strcmp(argv[i], "-timeout") == 0) {
+            // Tolerate -timeout for legacy uses.
+            if (argc < i + 3) {
+                error_print("--timeout needs time and units.");
+                usage(argc, argv);
+                return 0;
+            }
+            i++;
+            char* time_spec = argv[i++];
+            char* units = argv[i];
+            duration = atoll(time_spec);
+            // A parse error returns 0LL, so check to see whether that is what is meant.
+            if (duration == 0LL && strncmp(time_spec, "0", 1) != 0) {
+                // Parse error.
+                error_print("Invalid time value: %s", time_spec);
+                usage(argc, argv);
+                return 0;
+            }
+            if (strncmp(units, "sec", 3) == 0) {
+                duration = SEC(duration);
+            } else if (strncmp(units, "msec", 4) == 0) {
+                duration = MSEC(duration);
+            } else if (strncmp(units, "usec", 4) == 0) {
+                duration = USEC(duration);
+            } else if (strncmp(units, "nsec", 4) == 0) {
+                duration = NSEC(duration);
+            } else if (strncmp(units, "min", 3) == 0) {
+                duration = MINUTE(duration);
+            } else if (strncmp(units, "hour", 4) == 0) {
+                duration = HOUR(duration);
+            } else if (strncmp(units, "day", 3) == 0) {
+                duration = DAY(duration);
+            } else if (strncmp(units, "week", 4) == 0) {
+                duration = WEEK(duration);
+            } else {
+                // Invalid units.
+                error_print("Invalid time units: %s", units);
+                usage(argc, argv);
+                return 0;
+            }
+        } else if (strcmp(argv[i], "-k") == 0 || strcmp(argv[i], "--keepalive") == 0) {
+            if (argc < i + 2) {
+                error_print("--keepalive needs a boolean.");
+                usage(argc, argv);
+                return 0;
+            }
+            i++;
+            char* keep_spec = argv[i];
+            if (strcmp(keep_spec, "true") == 0) {
+                keepalive_specified = true;
+            } else if (strcmp(keep_spec, "false") == 0) {
+                keepalive_specified = false;
+            } else {
+                error_print("Invalid value for --keepalive: %s", keep_spec);
+            }
+        } else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--threads") == 0) {
+            if (argc < i + 2) {
+                error_print("--threads needs an integer argument.s");
+                usage(argc, argv);
+                return 0;
+            }
+            i++;
+            char* threads_spec = argv[i++];
+            int num_threads = atoi(threads_spec);
+            if (num_threads <= 0) {
+                error_print("Invalid value for --threads: %s. Using 1.", threads_spec);
+                num_threads = 1;
+            }
+            _lf_number_of_threads = (unsigned int)num_threads;
+        } else if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--id") == 0) {
+            if (argc < i + 2) {
+                error_print("--id needs a string argument.");
+                usage(argc, argv);
+                return 0;
+            }
+            i++;
+            info_print("Federation ID for executable %s: %s", argv[0], argv[i]);
+            federation_id = argv[i++];
+        } else {
+            error_print("Unrecognized command-line argument: %s", argv[i]);
+            usage(argc, argv);
+            return 0;
+        }
     }
     return 1;
 }

--- a/org.lflang/src/lib/core/reactor_common.c
+++ b/org.lflang/src/lib/core/reactor_common.c
@@ -520,7 +520,7 @@ lf_token_t* create_token(size_t element_size) {
  * @return Either the specified token or a new one, in each case with a value
  *  field pointing to newly allocated memory.
  */
-lf_token_t* __initialize_token_with_value(lf_token_t* token, void* value, int length) {
+lf_token_t* __initialize_token_with_value(lf_token_t* token, void* value, size_t length) {
     // assert(token != NULL);
 
     // If necessary, allocate memory for a new lf_token_t struct.
@@ -550,7 +550,7 @@ lf_token_t* __initialize_token_with_value(lf_token_t* token, void* value, int le
  * @return Either the specified token or a new one, in each case with a value
  *  field pointing to newly allocated memory.
  */
-lf_token_t* __initialize_token(lf_token_t* token, int length) {
+lf_token_t* __initialize_token(lf_token_t* token, size_t length) {
     // assert(token != NULL);
 
     // Allocate memory for storing the array.
@@ -1425,7 +1425,7 @@ handle_t _lf_schedule_int(void* action, interval_t extra_delay, int value) {
  * @return A pointer to the new or reused token or null if the template token
  *  is incompatible with this usage.
  */
-lf_token_t* __set_new_array_impl(lf_token_t* token, int length, int num_destinations) {
+lf_token_t* __set_new_array_impl(lf_token_t* token, size_t length, int num_destinations) {
     // If the template token cannot carry a payload, then it is incompatible.
     if (token->element_size == 0) {
         error_print("set_new_array: specified token cannot carry an array. It has zero element_size.");
@@ -1763,10 +1763,11 @@ int process_args(int argc, char* argv[]) {
     	   }
     	   i++;
     	   char* threads_spec = argv[i++];
-    	   _lf_number_of_threads = atoi(threads_spec);
-    	   if (_lf_number_of_threads <= 0) {
+    	   int num_threads = atoi(threads_spec);
+    	   if (num_threads <= 0) {
     	       error_print("Invalid value for --threads: %s", threads_spec);
     	   }
+           _lf_number_of_threads = (unsigned int)num_threads;
        } else if (strcmp(argv[i], "-i") == 0 || strcmp(argv[i], "--id") == 0) {
            if (argc < i + 2) {
                error_print("--id needs a string argument.");

--- a/org.lflang/src/lib/core/reactor_common.c
+++ b/org.lflang/src/lib/core/reactor_common.c
@@ -182,7 +182,7 @@ void set_stp_offset(interval_t offset) {
 void readable_time(char* buffer, instant_t time) {
     // If the number is negative or below 1000, just print it and return.
     if (time < 1000LL) {
-        sprintf(buffer, "%lld", time);
+        sprintf(buffer, "%lld", (long long)time);
         return;
     }
     int count = 0;
@@ -193,7 +193,7 @@ void readable_time(char* buffer, instant_t time) {
     }
     // Highest order clause should not be filled with zeros.
     instant_t to_print = clauses[--count] % 1000LL;
-    sprintf(buffer, "%lld", to_print);
+    sprintf(buffer, "%lld", (long long)to_print);
     if (to_print >= 100LL) {
         buffer += 3;
     } else if (to_print >= 10LL) {
@@ -203,7 +203,7 @@ void readable_time(char* buffer, instant_t time) {
     }
     while (count-- > 1) {
         to_print = clauses[count] % 1000LL;
-        sprintf(buffer, ",%03lld,", to_print);
+        sprintf(buffer, ",%03lld,", (long long)to_print);
         buffer += 4;
     }
     sprintf(buffer, ",%03lld", clauses[0] % 1000LL);

--- a/org.lflang/src/lib/core/reactor_threaded.c
+++ b/org.lflang/src/lib/core/reactor_threaded.c
@@ -1257,7 +1257,10 @@ lf_thread_t* __thread_ids;
 void start_threads() {
     LOG_PRINT("Starting %d worker threads.", _lf_number_of_threads);
     __thread_ids = (lf_thread_t*)malloc(_lf_number_of_threads * sizeof(lf_thread_t));
-    number_of_idle_threads = _lf_number_of_threads;
+    number_of_idle_threads = (int)_lf_number_of_threads; // Sign is checked when 
+                                                         // reading the argument
+                                                         // from the command
+                                                         // line.
     for (unsigned int i = 0; i < _lf_number_of_threads; i++) {
         lf_thread_create(&__thread_ids[i], worker, NULL);
     }

--- a/org.lflang/src/lib/core/reactor_threaded.c
+++ b/org.lflang/src/lib/core/reactor_threaded.c
@@ -318,7 +318,7 @@ handle_t _lf_schedule_token(void* action, interval_t extra_delay, lf_token_t* to
  * with a copy of the specified value.
  * See reactor.h for documentation.
  */
-handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, int length) {
+handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, size_t length) {
     if (value == NULL) {
         return _lf_schedule_token(action, offset, NULL);
     }
@@ -345,7 +345,7 @@ handle_t _lf_schedule_copy(void* action, interval_t offset, void* value, int len
  * Variant of schedule_token that creates a token to carry the specified value.
  * See reactor.h for documentation.
  */
-handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, int length) {
+handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* value, size_t length) {
     trigger_t* trigger = _lf_action_to_trigger(action);
 
     lf_mutex_lock(&mutex);

--- a/org.lflang/src/lib/core/rti.c
+++ b/org.lflang/src/lib/core/rti.c
@@ -1020,10 +1020,9 @@ void handle_address_query(uint16_t fed_id) {
     
     DEBUG_PRINT("RTI received address query from %d for %d.", fed_id, remote_fed_id);
 
-    assert(federates[remote_fed_id].server_port < 65536);
     // NOTE: server_port initializes to -1, which means the RTI does not know
     // the port number because it has not yet received an MSG_TYPE_ADDRESS_ADVERTISEMENT message
-    // from this federate. It will respond by sending -1.
+    // from this federate. In that case, it will respond by sending -1.
 
     // Encode the port number.
     encode_int32(federates[remote_fed_id].server_port, (unsigned char*)buffer);
@@ -1070,7 +1069,7 @@ void handle_address_ad(uint16_t federate_id) {
 
     server_port = extract_int32(buffer);
     
-    // FIXME: move assert < 65K here.
+    assert(server_port < 65536);
 
     pthread_mutex_lock(&rti_mutex);
     federates[federate_id].server_port = server_port;

--- a/org.lflang/src/lib/core/rti.c
+++ b/org.lflang/src/lib/core/rti.c
@@ -271,7 +271,7 @@ void handle_port_absent_message(federate_t* sending_federate, unsigned char* buf
     // issue a TAG before this message has been forwarded.
     pthread_mutex_lock(&rti_mutex);
 
-    unsigned short port_id = extract_ushort(&(buffer[1]));
+    unsigned short reactor_port_id = extract_ushort(&(buffer[1]));
     unsigned short federate_id = extract_ushort(&(buffer[1 + sizeof(unsigned short)]));
 
     // If the destination federate is no longer connected, issue a warning
@@ -284,7 +284,7 @@ void handle_port_absent_message(federate_t* sending_federate, unsigned char* buf
     }
 
     LOG_PRINT("RTI forwarding port absent message for port %u to federate %u.",
-                port_id,
+                reactor_port_id,
                 federate_id);
 
     // Need to make sure that the destination federate's thread has already
@@ -311,12 +311,12 @@ void handle_timed_message(federate_t* sending_federate, unsigned char* buffer) {
     // Read the header, minus the first byte which has already been read.
     read_from_socket_errexit(sending_federate->socket, header_size - 1, &(buffer[1]), "RTI failed to read the timed message header from remote federate.");
     // Extract the header information. of the sender
-    unsigned short port_id; // FIXME: Perhaps rename this to reactor_port_id to avoid confusion with network ports?
+    unsigned short reactor_port_id; // FIXME: Perhaps rename this to reactor_port_id to avoid confusion with network ports?
     unsigned short federate_id;
     unsigned int length;
     tag_t intended_tag;
     // Extract information from the header.
-    extract_timed_header(&(buffer[1]), &port_id, &federate_id, &length, &intended_tag);
+    extract_timed_header(&(buffer[1]), &reactor_port_id, &federate_id, &length, &intended_tag);
 
     unsigned int total_bytes_to_read = length + header_size;
     unsigned int bytes_to_read = length;
@@ -326,7 +326,7 @@ void handle_timed_message(federate_t* sending_federate, unsigned char* buffer) {
     }
 
     LOG_PRINT("RTI received message from federate %d for federate %u port %u. Forwarding.",
-            sending_federate->id, federate_id, port_id);
+            sending_federate->id, federate_id, reactor_port_id);
 
     read_from_socket_errexit(sending_federate->socket, bytes_to_read, &(buffer[header_size]),
                      "RTI failed to read timed message from federate %d.", federate_id);
@@ -361,7 +361,7 @@ void handle_timed_message(federate_t* sending_federate, unsigned char* buffer) {
     // Forward the message or message chunk.
     int destination_socket = federates[federate_id].socket;
 
-    DEBUG_PRINT("RTI forwarding message to port %d of federate %d of length %d.", port_id, federate_id, length);
+    DEBUG_PRINT("RTI forwarding message to port %d of federate %d of length %d.", reactor_port_id, federate_id, length);
     // Need to make sure that the destination federate's thread has already
     // sent the starting MSG_TYPE_TIMESTAMP message.
     while (federates[federate_id].state == PENDING) {

--- a/org.lflang/src/lib/core/rti.c
+++ b/org.lflang/src/lib/core/rti.c
@@ -258,6 +258,8 @@ int create_server(int32_t specified_port, uint16_t port, socket_type_t socket_ty
 
 /**
  * Handle a port absent message being received rom a federate via the RIT.
+ * 
+ * This function assumes the caller does not hold the mutex.
  */
 void handle_port_absent_message(federate_t* sending_federate, unsigned char* buffer) {
     size_t message_size = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int64_t) + sizeof(uint32_t);
@@ -302,9 +304,13 @@ void handle_port_absent_message(federate_t* sending_federate, unsigned char* buf
     pthread_mutex_unlock(&rti_mutex);
 }
 
-/** Handle a timed message being received from a federate by the RTI to relay to another federate.
- *  @param sending_federate The sending federate.
- *  @param buffer The buffer to read into (the first byte is already there).
+/** 
+ * Handle a timed message being received from a federate by the RTI to relay to another federate.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
+ * @param sending_federate The sending federate.
+ * @param buffer The buffer to read into (the first byte is already there).
  */
 void handle_timed_message(federate_t* sending_federate, unsigned char* buffer) {
     size_t header_size = 1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t) + sizeof(int64_t) + sizeof(uint32_t);
@@ -712,6 +718,9 @@ bool send_tag_advance_if_appropriate(federate_t* fed) {
 
 /**
  * Handle a logical tag complete (LTC) message.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
  * @param fed The federate that has completed a logical tag.
  */
 void handle_logical_tag_complete(federate_t* fed) {
@@ -759,6 +768,9 @@ void transitive_send_TAG_if_appropriate(federate_t* fed, bool visited[]) {
 
 /**
  * Handle a next event tag (NET) message.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
  * @param fed The federate sending a NET message.
  */
 void handle_next_event_tag(federate_t* fed) {
@@ -793,6 +805,9 @@ void handle_next_event_tag(federate_t* fed) {
 
 /**
  * Handle a time advance notice (TAN) message.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
  * @param fed The federate sending a TAN message.
  */
 void handle_time_advance_notice(federate_t* fed) {
@@ -900,6 +915,9 @@ void mark_federate_requesting_stop(federate_t* fed) {
 
 /**
  * Handle a MSG_TYPE_STOP_REQUEST message.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
  * @param fed The federate sending a MSG_TYPE_STOP_REQUEST message.
  */
 void handle_stop_request_message(federate_t* fed) {
@@ -970,6 +988,9 @@ void handle_stop_request_message(federate_t* fed) {
 
 /** 
  * Handle a MSG_TYPE_STOP_REQUEST_REPLY message.
+ * 
+ * This function assumes the caller does not hold the mutex.
+ * 
  * @param fed The federate replying the MSG_TYPE_STOP_REQUEST
  */
 void handle_stop_request_reply(federate_t* fed) {
@@ -1005,7 +1026,7 @@ void handle_stop_request_reply(federate_t* fed) {
  * are initialized to -1. If no MSG_TYPE_ADDRESS_ADVERTISEMENT message has been received from
  * the destination federate, the RTI will simply reply with -1 for the port.
  * The sending federate is responsible for checking back with the RTI after a 
- * period of time. @see connect_to_federate() in federate.c.
+ * period of time. @see connect_to_federate() in federate.c. * 
  * @param fed_id The federate sending a MSG_TYPE_ADDRESS_QUERY message.
  */
 void handle_address_query(uint16_t fed_id) {
@@ -1050,6 +1071,8 @@ void handle_address_query(uint16_t fed_id) {
  * The server_hostname and server_ip_addr fields are assigned
  * in connect_to_federates() upon accepting the socket
  * from the remote federate.
+ * 
+ * This function assumes the caller does not hold the mutex.
  * 
  * @param federate_id The id of the remote federate that is
  *  sending the address advertisement.
@@ -1328,6 +1351,8 @@ void* clock_synchronization_thread(void* noargs) {
  * on the federate. This function assumes
  * that the caller does not hold the mutex
  * lock.
+ * 
+ * This function assumes the caller does not hold the mutex.
  * 
  * @note At this point, the RTI might have
  * outgoing messages to the federate. This

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -474,7 +474,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Byte identifying a address query message, sent by a federate to RTI
  * to ask for another federate's address and port number.
  * The next two bytes are the other federate's ID.
- * The reply from the RTI will a port number (an int), which is -1
+ * The reply from the RTI will a port number (an int32_t), which is -1
  * if the RTI does not know yet (it has not received MSG_TYPE_ADDRESS_ADVERTISEMENT from
  * the other federate), followed by the IP address of the other
  * federate (an IPV4 address, which has length INET_ADDRSTRLEN).
@@ -485,7 +485,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Byte identifying a message advertising the port for the TCP connection server
  * of a federate. This is utilized in decentralized coordination as well as for physical
  * connections in centralized coordination.
- * The next four bytes (or sizeof(int)) will be the port number.
+ * The next four bytes (or sizeof(int32_t)) will be the port number.
  * The sending federate will not wait for a response from the RTI and assumes its
  * request will be processed eventually by the RTI.
  */
@@ -641,7 +641,7 @@ typedef enum fed_state_t {
  * any scheduling constraints.
  */
 typedef struct federate_t {
-    int id;                 // ID of this federate.
+    int32_t id;             // ID of this federate.
     pthread_t thread_id;    // The ID of the thread handling communication with this federate.
     int socket;             // The TCP socket descriptor for communicating with this federate.
     struct sockaddr_in UDP_addr;           // The UDP address for the federate.
@@ -661,7 +661,7 @@ typedef struct federate_t {
     int num_downstream;     // Size of the array of downstream federates.
     execution_mode_t mode;  // FAST or REALTIME.
     char server_hostname[INET_ADDRSTRLEN]; // Human-readable IP address and
-    int server_port;        // port number of the socket server of the federate
+    int32_t server_port;    // port number of the socket server of the federate
                             // if it has any incoming direct connections from other federates.
                             // The port number will be -1 if there is no server or if the
                             // RTI has not been informed of the port number.

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -187,7 +187,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * This is used by both the federates and the rti, so message lengths
  * should generally match.
  */
-#define FED_COM_BUFFER_SIZE 256
+#define FED_COM_BUFFER_SIZE 256u
 
 /**
  * Number of seconds that elapse between a federate's attempts
@@ -434,7 +434,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ENCODE_STOP_REQUEST(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST; \
     encode_int64(time, &(buffer[1])); \
-    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    assert(microstep >= 0); \
+    encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /**
@@ -450,7 +451,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ENCODE_STOP_REQUEST_REPLY(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST_REPLY; \
     encode_int64(time, &(buffer[1])); \
-    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    assert(microstep >= 0); \
+    encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /**
@@ -465,7 +467,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define ENCODE_STOP_GRANTED(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_GRANTED; \
     encode_int64(time, &(buffer[1])); \
-    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    assert(microstep >= 0); \
+    encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /////////// End of request_stop() messages ////////////////
@@ -641,7 +644,7 @@ typedef enum fed_state_t {
  * any scheduling constraints.
  */
 typedef struct federate_t {
-    int32_t id;             // ID of this federate.
+    uint16_t id;            // ID of this federate.
     pthread_t thread_id;    // The ID of the thread handling communication with this federate.
     int socket;             // The TCP socket descriptor for communicating with this federate.
     struct sockaddr_in UDP_addr;           // The UDP address for the federate.

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -308,6 +308,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * time as a message of this type.
  s*/
 #define MSG_TYPE_TIMESTAMP 2
+#define MSG_TYPE_TIMESTAMP_LENGTH (1 + sizeof(int64_t))
 
 /** Byte identifying a message to forward to another federate.
  *  The next two bytes will be the ID of the destination port.
@@ -430,7 +431,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * other federate, then it should be possible to respect its requested stop tag.
  */
 #define MSG_TYPE_STOP_REQUEST 10
-#define STOP_REQUEST_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
+#define MSG_TYPE_STOP_REQUEST_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_REQUEST(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST; \
     encode_int64(time, &(buffer[1])); \
@@ -447,7 +448,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The next 4 bytes will be the microstep.
  */
 #define MSG_TYPE_STOP_REQUEST_REPLY 11
-#define STOP_REQUEST_REPLY_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
+#define MSG_TYPE_STOP_REQUEST_REPLY_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_REQUEST_REPLY(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST_REPLY; \
     encode_int64(time, &(buffer[1])); \
@@ -463,7 +464,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The next 4 bytes will be the microstep at which the federates will stop..
  */
 #define MSG_TYPE_STOP_GRANTED 12
-#define STOP_GRANTED_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
+#define MSG_TYPE_STOP_GRANTED_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_GRANTED(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_GRANTED; \
     encode_int64(time, &(buffer[1])); \

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -228,7 +228,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * try again. The number of increments is limited by PORT_RANGE_LIMIT.
  * FIXME: Clarify what happens if a specific port has been given in "at".
  */
-#define STARTING_PORT 15045
+#define STARTING_PORT 15045u
 
 /**
  * Number of ports to try to connect to. Unless the LF program specifies

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -130,7 +130,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * server to listen for incoming connections from those federates.
  * It attempts to create the server at the port given by STARTING_PORT,
  * and if this fails, increments the port number from there until a
- * port is available. It then sends to the RTI an MSG_TYPE_ADDRESS_AD message
+ * port is available. It then sends to the RTI an MSG_TYPE_ADDRESS_ADVERTISEMENT message
  * with the port number as a payload. The federate then creates a thread
  * to listen for incoming socket connections and messages.
  *
@@ -324,11 +324,11 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MSG_TYPE_RESIGN 4
 
 /** Byte identifying a timestamped message to forward to another federate.
- *  The next two bytes will be the ID of the destination port.
+ *  The next two bytes will be the ID of the destination reactor port.
  *  The next two bytes are the destination federate ID.
  *  The four bytes after that will be the length of the message.
- *  The next eight bytes will be the timestamp.
- *  The next four bytes will be the microstep of the sender.
+ *  The next eight bytes will be the timestamp of the message.
+ *  The next four bytes will be the microstep of the message.
  *  The remaining bytes are the message.
  *
  *  With centralized coordination, all such messages flow through the RTI.
@@ -475,20 +475,21 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * to ask for another federate's address and port number.
  * The next two bytes are the other federate's ID.
  * The reply from the RTI will a port number (an int), which is -1
- * if the RTI does not know yet (it has not received MSG_TYPE_ADDRESS_AD from
+ * if the RTI does not know yet (it has not received MSG_TYPE_ADDRESS_ADVERTISEMENT from
  * the other federate), followed by the IP address of the other
  * federate (an IPV4 address, which has length INET_ADDRSTRLEN).
  */
 #define MSG_TYPE_ADDRESS_QUERY 13
 
 /**
- * Byte identifying a message advertising the port for the physical connection server
- * of a federate.
+ * Byte identifying a message advertising the port for the TCP connection server
+ * of a federate. This is utilized in decentralized coordination as well as for physical
+ * connections in centralized coordination.
  * The next four bytes (or sizeof(int)) will be the port number.
  * The sending federate will not wait for a response from the RTI and assumes its
  * request will be processed eventually by the RTI.
  */
-#define MSG_TYPE_ADDRESS_AD 14
+#define MSG_TYPE_ADDRESS_ADVERTISEMENT 14
 
 /**
  * Byte identifying a first message that is sent by a federate directly to another federate

--- a/org.lflang/src/lib/core/rti.h
+++ b/org.lflang/src/lib/core/rti.h
@@ -433,8 +433,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define STOP_REQUEST_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_REQUEST(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST; \
-    encode_ll(time, &(buffer[1])); \
-    encode_int(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    encode_int64(time, &(buffer[1])); \
+    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /**
@@ -449,8 +449,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define STOP_REQUEST_REPLY_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_REQUEST_REPLY(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_REQUEST_REPLY; \
-    encode_ll(time, &(buffer[1])); \
-    encode_int(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    encode_int64(time, &(buffer[1])); \
+    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /**
@@ -464,8 +464,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define STOP_GRANTED_MESSAGE_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 #define ENCODE_STOP_GRANTED(buffer, time, microstep) do { \
     buffer[0] = MSG_TYPE_STOP_GRANTED; \
-    encode_ll(time, &(buffer[1])); \
-    encode_int(microstep, &(buffer[1 + sizeof(instant_t)])); \
+    encode_int64(time, &(buffer[1])); \
+    encode_int32(microstep, &(buffer[1 + sizeof(instant_t)])); \
 } while(0)
 
 /////////// End of request_stop() messages ////////////////

--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -334,7 +334,7 @@ class CGenerator extends GeneratorBase {
         super()
         // set defaults
         targetConfig.compiler = "gcc"
-        targetConfig.compilerFlags.add("-O2") // -Wall -Wconversion"
+        targetConfig.compilerFlags.addAll("-O2", "-Wconversion") // "-Wall -Wconversion"
     }
 
     ////////////////////////////////////////////

--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -1065,7 +1065,8 @@ class CGenerator extends GeneratorBase {
                 return -1;
             }
             printf("Starting RTI for %d federates in federation ID %s\n", NUMBER_OF_FEDERATES, federation_id);
-            for (int i = 0; i < NUMBER_OF_FEDERATES; i++) {
+            assert(NUMBER_OF_FEDERATES < UINT16_MAX);
+            for (uint16_t i = 0; i < NUMBER_OF_FEDERATES; i++) {
                 initialize_federate(i);
                 «IF targetConfig.fastMode»
                     federates[i].mode = FAST;

--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -334,7 +334,7 @@ class CGenerator extends GeneratorBase {
         super()
         // set defaults
         targetConfig.compiler = "gcc"
-        targetConfig.compilerFlags.addAll("-O2", "-Wconversion") // "-Wall -Wconversion"
+        targetConfig.compilerFlags.addAll("-O2") // "-Wall -Wconversion"
     }
 
     ////////////////////////////////////////////


### PR DESCRIPTION
With notes from @oowekyala:

# Code review 6.24
_NOTE: line numbers are only more or less accurate bc marten added some comments_
## rti.c
### High-level comment
- Federates may have a different instant_t. Since the RTI needs to find max of timestamps received from each federates, it needs to assume that the message fits in some number of bytes
- So the federation may break if federates have different concrete data types for eg instant_t (probs also for int)
- instances of `sizeof(int)` and `sizeof(long long)` should be replaced with data types that have fixed width
### `handle_timestamp(fed_t)`
L1115: 2nd write to socket
 - receiver of the data may see just the message header, and block waiting for the body, if an error occurs between both `write_to_socket` calls. Should be consolidated into single write.
L1123:
 - we're holding the lock until the end of the function, including a write to a socket
### `handle_address_ad(ushort)`
- couple of renamings "ad" -> "advertisement", including constant `MSG_TYPE_ADDRESS_AD` -> `MSG_TYPE_ADDRESS_ADVERTISEMENT`
L1062:
  - move assert that checks that the server port is a valid number (< 2^16) into here, to check it before storing it.
