### PR TITLE
Enable Branch Selection in Oomph Setup

### DIFF
--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -135,7 +135,7 @@
   <setupTask
       xsi:type="setup:VariableTask"
       name="eclipse.target.platform"
-      defaultValue="2021-03"
+      value="2021-06"
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">

--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -181,12 +181,12 @@
   </setupTask>
   <setupTask
       xsi:type="setup:VariableTask"
+      id="git.clone.lingua.franca.branch"
       name="git.clone.lingua.franca.branch"
-      value="master"
       defaultValue="master"
       storageURI="scope://Workspace"
-      label="">
-    <description></description>
+      label="Lingua Franca Branch (git clone)">
+    <description>The branch to check out at the initial clone of the repository.</description>
   </setupTask>
   <setupTask
       xsi:type="git:GitCloneTask"


### PR DESCRIPTION
This allow the user to specify the branch (via _Lingua Franca Branch (git clone)_) that will be checked out at the initial clone of the repository during installation.

![project_configuration](https://user-images.githubusercontent.com/25612037/124150185-a21f3780-da91-11eb-88d6-36aa248ad965.png)

It has the downside that everyone who already has an existing installation, will be prompted (once) for a value for this new user variable but I think this is acceptable.

![branch_user_prompt](https://user-images.githubusercontent.com/25612037/124150535-f1fdfe80-da91-11eb-9458-7a434e9ff353.png)

This tackles Problem 2 in #383

As soon as this PR is merged I will adjust the screen shot in the [oomph setup tutorial](https://github.com/icyphy/lingua-franca/wiki/Developer-Eclipse-Setup-with-Oomph).

The [second commit regarding the target platform variable](https://github.com/icyphy/lingua-franca/commit/828a38985ae20f7a008ffc68f8fbe84326451b1d) is unrelated to the main problem.