### PR TITLE
Deactivates Automatic Generation of Maven Target Platform from Oomph

### DIFF
--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -297,25 +297,6 @@
           name="${scope.project.label}"
           activeRepositoryList="DefaultRepositories"
           includeSources="false">
-        <annotation
-            source="http:/www.eclipse.org/oomph/targlets/TargetDefinitionGenerator">
-          <detail
-              key="preferredRepositories">
-            <value>http://download.eclipse.org/eclipse/updates/</value>
-          </detail>
-          <detail
-              key="includeAllPlatforms">
-            <value>false</value>
-          </detail>
-          <detail
-              key="includeSource">
-            <value>false</value>
-          </detail>
-          <detail
-              key="location">
-            <value>${git.clone.lingua.franca.location}/org.lflang.targetplatform/org.lflang.targetplatform.target</value>
-          </detail>
-        </annotation>
         <requirement
             name="org.eclipse.equinox.executable.feature.group"/>
         <requirement

--- a/org.lflang.targetplatform/org.lflang.targetplatform.target
+++ b/org.lflang.targetplatform/org.lflang.targetplatform.target
@@ -1,51 +1,34 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated from Lingua Franca" sequenceNumber="8">
+<target name="Lingua Franca Target Platform (manually maintained)">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="jakarta.xml.bind" version="0.0.0"/>
-      <unit id="javaewah" version="0.0.0"/>
-      <unit id="javax.xml" version="0.0.0"/>
-      <unit id="net.i2p.crypto.eddsa" version="0.0.0"/>
-      <unit id="org.aopalliance" version="0.0.0"/>
-      <unit id="org.apache.sshd.osgi" version="0.0.0"/>
-      <unit id="org.apache.sshd.sftp" version="0.0.0"/>
+      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.cdt.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf" version="0.0.0"/>
-      <unit id="org.eclipse.emf.transaction" version="0.0.0"/>
+      <unit id="org.eclipse.emf.mwe2.launcher.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.epp.mpc.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.lsp4e" version="0.0.0"/>
-      <unit id="org.eclipse.lsp4e.debug" version="0.0.0"/>
-      <unit id="org.eclipse.m2e.jdt" version="0.0.0"/>
-      <unit id="org.eclipse.platform.doc.isv" version="0.0.0"/>
+      <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xpand.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.tm4e.languageconfiguration" version="0.0.0"/>
+      <unit id="javax.xml" version="0.0.0"/>
+      <unit id="jakarta.xml.bind" version="0.0.0"/>
+      <unit id="org.eclipse.lsp4e" version="0.0.0"/>
+      <unit id="org.eclipse.emf" version="0.0.0"/>
+      <unit id="org.aopalliance" version="0.0.0"/>
       <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.jsoup" version="0.0.0"/>
       <repository location="http://download.eclipse.org/releases/2021-06"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.python.pydev.feature.feature.group" version="0.0.0"/>
-      <repository location="https://www.pydev.org/updates/"/>
+      <unit id="org.eclipse.xtext.runtime.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xtext.ui.feature.group" version="0.0.0"/>
+      <repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/releases/2.25.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="de.cau.cs.kieler.klighd.freehep.feature.feature.group" version="0.0.0"/>
-      <unit id="de.cau.cs.kieler.klighd.ui.contrib3x" version="0.0.0"/>
-      <unit id="de.cau.cs.kieler.klighd.view.feature.feature.group" version="0.0.0"/>
-      <repository location="https://kieler.github.io/KLighD/v2.0.0/"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.elk.graphviz.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/elk/updates/releases/0.7.1/"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/wildwebdeveloper/releases/latest/"/>
+      <unit id="com.google.inject" version="0.0.0"/>
+      <unit id="jakarta.activation" version="0.0.0"/>
+      <unit id="javax.activation" version="0.0.0"/>
+      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.jetbrains.kotlin.feature.feature.group" version="0.0.0"/>
@@ -56,16 +39,26 @@
       <repository location="http://download.eclipse.org/tools/ajdt/410/dev/update"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="org.python.pydev.feature.feature.group" version="0.0.0"/>
+      <repository location="https://www.pydev.org/updates/"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="org.eclipse.wildwebdeveloper.feature.feature.group" version="0.0.0"/>
+      <repository location="http://download.eclipse.org/wildwebdeveloper/releases/latest/"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+      <unit id="de.cau.cs.kieler.klighd.feature.feature.group" version="0.0.0"/>
+      <unit id="de.cau.cs.kieler.klighd.ide.feature.feature.group" version="0.0.0"/>
+      <unit id="de.cau.cs.kieler.klighd.view.feature.feature.group" version="0.0.0"/>
       <unit id="de.cau.cs.kieler.klighd.freehep.feature.feature.group" version="0.0.0"/>
       <unit id="de.cau.cs.kieler.klighd.ui.contrib3x" version="0.0.0"/>
-      <unit id="de.cau.cs.kieler.klighd.view.feature.feature.group" version="0.0.0"/>
       <repository location="https://kieler.github.io/KLighD/v2.0.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
-      <unit id="com.google.inject" version="0.0.0"/>
-      <unit id="jakarta.activation" version="0.0.0"/>
-      <unit id="javax.activation" version="0.0.0"/>
-      <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
+      <unit id="org.eclipse.elk.graphviz.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
+      <repository location="http://download.eclipse.org/elk/updates/releases/0.7.1/"/>
     </location>
   </locations>
 </target>


### PR DESCRIPTION
This will prevent the oomph setup from adding platform specific fragments/plugins into the target platform definition file (org.lflang.targetplatform.target) for maven. On the downside, this means the file has be manually synchronized with the target definition in the oomph setup.
This should be documented in the process for adding new dependencies and updating of dependency versions (e.g. changes to update sites).

This tackles Problem 1 in #383

In the transition period, it might be possible that a merge/PR with an automatically generated target file could conflict. Usually this new (manual) version should prevail entirely but you can contact me if it seems that generated target file actually extended the scope of dependencies.