### PR TITLE
Adjust grammar to distinguish paranthesis and brace based initialization in C++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ crashlytics-build.properties
 fabric.properties
 
 ### Maven ###
-target/
+/org.lflang*/target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -888,7 +888,11 @@ class ASTUtils {
                     for (s : type.stars ?: emptyList) {
                         stars += s
                     }
-                    return type.id + stars
+                    if (!type.typeParms.isNullOrEmpty) {
+                        return '''«type.id»<«FOR p : type.typeParms SEPARATOR ", "»«p.toText»«ENDFOR»>''' 
+                    } else {
+                        return type.id + stars                        
+                    }
                 }
             }
         }

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -69,6 +69,8 @@ import org.lflang.lf.Value
 import org.lflang.lf.VarRef
 import org.lflang.lf.WidthSpec
 
+import static extension org.eclipse.emf.ecore.util.EcoreUtil.*
+
 /**
  * A helper class for modifying and analyzing the AST.
  * @author{Marten Lohstroh <marten@berkeley.edu>}
@@ -415,18 +417,7 @@ class ASTUtils {
         }
         return name + suffix
     }
-    
-    /**
-     * Given a AST node, return a deep copy of that node.
-     * @param original The original to create a deep copy of.
-     * @return A deep copy of the given AST node.
-     */
-    static def <T extends EObject> T getCopy (T original) {
-        if (original !== null) {
-            return EcoreUtil.copy(original) as T
-        }
-    }
-        
+   
     ////////////////////////////////
     //// Utility functions for supporting inheritance
     

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -417,51 +417,13 @@ class ASTUtils {
     }
     
     /**
-     * Given a "type" AST node, return a deep copy of that node.
+     * Given a AST node, return a deep copy of that node.
      * @param original The original to create a deep copy of.
      * @return A deep copy of the given AST node.
      */
-    private static def getCopy(TypeParm original) {
-        val clone = factory.createTypeParm
-        if (!original.literal.isNullOrEmpty) {
-            clone.literal = original.literal
-        } else if (original.code !== null) {
-                clone.code = factory.createCode
-                clone.code.body = original.code.body
-        }
-        return clone
-    }
-    
-    /**
-     * Given a "type" AST node, return a deep copy of that node.
-     * @param original The original to create a deep copy of.
-     * @return A deep copy of the given AST node.
-     */
-     static def getCopy(Type original) {
+    static def <T extends EObject> T getCopy (T original) {
         if (original !== null) {
-            val clone = factory.createType
-            
-            clone.id = original.id
-            // Set the type based on the argument type.
-            if (original.code !== null) {
-                clone.code = factory.createCode
-                clone.code.body = original.code.body
-            } 
-            if (original.stars !== null) {
-                original.stars?.forEach[clone.stars.add(it)]
-            }
-                
-            if (original.arraySpec !== null) {
-                clone.arraySpec = factory.createArraySpec
-                clone.arraySpec.ofVariableLength = original.arraySpec.
-                    ofVariableLength
-                clone.arraySpec.length = original.arraySpec.length
-            }
-            clone.time = original.time
-            
-            original.typeParms?.forEach[parm | clone.typeParms.add(parm.copy)]
-            
-            return clone
+            return EcoreUtil.copy(original) as T
         }
     }
         

--- a/org.lflang/src/org/lflang/ASTUtils.xtend
+++ b/org.lflang/src/org/lflang/ASTUtils.xtend
@@ -1456,7 +1456,7 @@ class ASTUtils {
      * @return True if the variable was initialized, false otherwise.
      */
     def static boolean isInitialized(StateVar v) {
-        if (v !== null && v.parens.size == 2) {
+        if (v !== null && (v.parens.size == 2 || v.braces.size == 2)) {
             return true
         }
         return false

--- a/org.lflang/src/org/lflang/AstExtensions.kt
+++ b/org.lflang/src/org/lflang/AstExtensions.kt
@@ -349,7 +349,7 @@ val Port.inferredType: InferredType get() = ASTUtils.getInferredType(this)
  * @receiver The state variable to be checked.
  * @return True if the variable was initialized, false otherwise.
  */
-val StateVar.isInitialized: Boolean get() = (this.parens.size == 2)
+val StateVar.isInitialized: Boolean get() = (this.parens.size == 2 || this.braces.size == 2)
 
 /**
  * Given the width specification of port or instantiation

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -137,8 +137,8 @@ TargetDecl:
  StateVar:
     'state' name=ID (
         (':' (type=Type))? 
-        (parens+='(' (init+=Value 
-                (','  init+=Value)*)? parens+=')'
+        ((parens+='(' (init+=Value (','  init+=Value)*)? parens+=')')
+            | (braces+='{' (init+=Value (','  init+=Value)*)? braces+='}')
         )?
     ) ';'?
 ;
@@ -274,8 +274,9 @@ Assignment:
  */
 Parameter:
     name=ID (':' (type=Type))? 
-    (parens+='(' (init+=Value                   // FIXME: rename Value to Expr
-            (','  init+=Value)*)? parens+=')'
+    // FIXME: rename Value to Expr
+    ((parens+='(' (init+=Value (','  init+=Value)*)? parens+=')')
+        | (braces+='{' (init+=Value (','  init+=Value)*)? braces+='}')
     )?
 ;
 

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -317,7 +317,10 @@ Port:
     
 // A type is in the target language, hence either an ID or target code.
 Type:
-   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) ('<' typeParms+=Type (',' typeParms+=Type)* '>')? (stars+='*')* (arraySpec=ArraySpec)?) | code=Code);
+   time?='time' (arraySpec=ArraySpec)? 
+   | id=DottedName ('<' typeParms+=Type (',' typeParms+=Type)* '>')? (stars+='*')* (arraySpec=ArraySpec)? 
+   | code=Code
+;
 
 ArraySpec:
     ofVariableLength?='[]' | '[' length=INT ']';

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -311,7 +311,7 @@ Port:
     
 // A type is in the target language, hence either an ID or target code.
 Type:
-   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? (stars+='*')* (arraySpec=ArraySpec)?) | code=Code);
+   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) ('<' typeParms+=Type (',' typeParms+=Type)* '>')? (stars+='*')* (arraySpec=ArraySpec)?) | code=Code);
 
 ArraySpec:
     ofVariableLength?='[]' | '[' length=INT ']';

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -267,7 +267,12 @@ VarRef:
     | container=[Instantiation] '.' variable=[Variable];
 
 Assignment:
-    (lhs=[Parameter] (('=' rhs+=Value) | ( '='? '(' (rhs+=Value(','  rhs+=Value)*)? ')')));
+    (lhs=[Parameter] (
+        (equals='=' rhs+=Value)
+        | ((equals='=')? (
+            parens+='(' (rhs+=Value (',' rhs+=Value)*)? parens+=')'
+            | braces+='{' (rhs+=Value (',' rhs+=Value)*)? braces+='}'))
+    ));
 
 /**
  * Parameter declaration with optional type and mandatory initialization.

--- a/org.lflang/src/org/lflang/LinguaFranca.xtext
+++ b/org.lflang/src/org/lflang/LinguaFranca.xtext
@@ -311,7 +311,7 @@ Port:
     
 // A type is in the target language, hence either an ID or target code.
 Type:
-   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) (stars+='*')* ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? (arraySpec=ArraySpec)?) | code=Code);
+   (time?='time' (arraySpec=ArraySpec)?) | ((id=(DottedName) ('<' typeParms+=TypeParm (',' typeParms+=TypeParm)* '>')? (stars+='*')* (arraySpec=ArraySpec)?) | code=Code);
 
 ArraySpec:
     ofVariableLength?='[]' | '[' length=INT ']';

--- a/org.lflang/src/org/lflang/federated/FedASTUtils.java
+++ b/org.lflang/src/org/lflang/federated/FedASTUtils.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.lflang.ASTUtils;
 import org.lflang.TargetProperty.CoordinationType;
 import org.lflang.TimeValue;
@@ -101,8 +102,8 @@ public class FedASTUtils {
     ) {
         LfFactory factory = LfFactory.eINSTANCE;
         Reaction reaction = factory.createReaction();
-        VarRef newPortRef = factory.createVarRef();        
-        Type portType = ASTUtils.getCopy(destination.getDefinition().getType());
+        VarRef newPortRef = factory.createVarRef();
+        Type portType = EcoreUtil.copy(destination.getDefinition().getType());
         
         // If the sender or receiver is in a bank of reactors, then we want
         // these reactions to appear only in the federate whose bank ID matches.
@@ -406,7 +407,7 @@ public class FedASTUtils {
     ) {
         LfFactory factory = LfFactory.eINSTANCE;
         // Assume all the types are the same, so just use the first on the right.
-        Type type = ASTUtils.getCopy(source.getDefinition().getType());
+        Type type = EcoreUtil.copy(source.getDefinition().getType());
         Action action = factory.createAction();
         VarRef triggerRef = factory.createVarRef();
         VarRef sourceRef = factory.createVarRef();

--- a/org.lflang/src/org/lflang/generator/cpp/CppInstanceGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppInstanceGenerator.kt
@@ -25,6 +25,7 @@
 package org.lflang.generator.cpp
 
 import org.lflang.*
+import org.lflang.generator.cpp.CppParameterGenerator.Companion.targetType
 import org.lflang.lf.Instantiation
 import org.lflang.lf.Parameter
 import org.lflang.lf.Reactor
@@ -64,8 +65,22 @@ class CppInstanceGenerator(
             with(CppParameterGenerator) { param.defaultValue }
         } else {
             // Otherwise, we use the assigned value.
-            val initializers = assignment.rhs.map { if (param.isOfTimeType) it.toTime() else it.toCode() }
-            with(CppParameterGenerator) { param.generateInstance(initializers) }
+            if (assignment.equals == "=") {
+                if (!assignment.braces.isNullOrEmpty()) {
+                    "{${assignment.rhs.joinToString(", ") { it.toCode() }}}"
+                } else if (!assignment.parens.isNullOrEmpty()) {
+                    "(${assignment.rhs.joinToString(", ") { it.toCode() }})"
+                } else {
+                    assert(assignment.rhs.size == 1)
+                    assignment.rhs[0].toCode()
+                }
+            } else {
+                if (!assignment.braces.isNullOrEmpty()) {
+                    "${param.targetType}{${assignment.rhs.joinToString(", ") { it.toCode() }}}"
+                } else {
+                    "${param.targetType}(${assignment.rhs.joinToString(", ") { it.toCode() }})"
+                }
+            }
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
@@ -47,18 +47,11 @@ class CppParameterGenerator(private val reactor: Reactor) {
         /** Type of the parameter in C++ code */
         val Parameter.targetType get():String = this.inferredType.targetType
 
-        /** Get a parameter instantiated from the given initializer list */
-        fun Parameter.generateInstance(initializers: List<String>): String {
-            val leftParen = if (!parens.isNullOrEmpty()) "(" else "{"
-            val rightParen = if (!parens.isNullOrEmpty()) ")" else "}"
-            return when {
-                initializers.size > 1  -> "$targetType$leftParen${initializers.joinToString(", ")}$rightParen"
-                initializers.size == 1 -> initializers[0]
-                else                   -> "$targetType()"
-            }}
-
         /** Get the default value of the receiver parameter in C++ code */
-        val Parameter.defaultValue: String get() = generateInstance(getInitializerList())
+        val Parameter.defaultValue: String
+            get() =
+                if (braces?.size == 2) "$targetType{${getInitializerList().joinToString(", ")}}"
+                else "$targetType(${getInitializerList().joinToString(", ")})"
 
         /** Get a C++ type that is a const reference to the parameter type */
         val Parameter.constRefType: String

--- a/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
@@ -48,12 +48,14 @@ class CppParameterGenerator(private val reactor: Reactor) {
         val Parameter.targetType get():String = this.inferredType.targetType
 
         /** Get a parameter instantiated from the given initializer list */
-        fun Parameter.generateInstance(initializers: List<String>) =
-            when {
-                initializers.size > 1  -> "$targetType{${initializers.joinToString(", ")}}"
+        fun Parameter.generateInstance(initializers: List<String>): String {
+            val leftParen = if (!parens.isNullOrEmpty()) "(" else "{"
+            val rightParen = if (!parens.isNullOrEmpty()) ")" else "}"
+            return when {
+                initializers.size > 1  -> "$targetType$leftParen${initializers.joinToString(", ")}$rightParen"
                 initializers.size == 1 -> initializers[0]
-                else                   -> "$targetType{}"
-            }
+                else                   -> "$targetType()"
+            }}
 
         /** Get the default value of the receiver parameter in C++ code */
         val Parameter.defaultValue: String get() = generateInstance(getInitializerList())

--- a/org.lflang/src/org/lflang/generator/cpp/CppStateGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppStateGenerator.kt
@@ -45,9 +45,12 @@ class CppStateGenerator(private val reactor: Reactor) {
         }
     }
 
-    private fun generateInitializer(state: StateVar): String {
-        return "${state.name}{${getInitializerList(state).joinToString(separator = ", ")}}"
-    }
+    private fun generateInitializer(state: StateVar): String =
+        if (state.parens.isNullOrEmpty())
+            "${state.name}{${getInitializerList(state).joinToString(separator = ", ")}}"
+        else
+            "${state.name}(${getInitializerList(state).joinToString(separator = ", ")})"
+
 
     /** Get all state declarations */
     fun generateDeclarations() =

--- a/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
+++ b/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
@@ -310,6 +310,11 @@ class LFValidatorImpl extends AbstractLFValidator {
                     Literals.ASSIGNMENT__RHS)
             }
         }
+
+        if(!assignment.braces.isNullOrEmpty() && this.target != Target.CPP) {
+            error("Brace initializers are only supported for the C++ target", Literals.ASSIGNMENT__BRACES)
+        }
+
         // FIXME: lhs is list => rhs is list
         // lhs is fixed with size n => rhs is fixed with size n
         // FIXME": similar checks for decl/init

--- a/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
+++ b/org.lflang/src/org/lflang/validation/LFValidatorImpl.xtend
@@ -757,6 +757,11 @@ class LFValidatorImpl extends AbstractLFValidator {
                     TimeValue.MAX_LONG_DEADLINE + " nanoseconds.",
                 Literals.PARAMETER__INIT)
         }
+        
+        if(!param.braces.isNullOrEmpty && this.target != Target.CPP) {
+            error("Brace initializers are only supported for the C++ target", Literals.PARAMETER__BRACES)
+        }
+        
     }
 
     @Check(FAST)
@@ -1130,7 +1135,10 @@ class LFValidatorImpl extends AbstractLFValidator {
                     Literals.STATE_VAR__INIT)
             }
         }
-
+        
+        if(!stateVar.braces.isNullOrEmpty && this.target != Target.CPP) {
+            error("Brace initializers are only supported for the C++ target", Literals.STATE_VAR__BRACES)
+        }
     }
 
     @Check(FAST)

--- a/test/Cpp/src/ActionDelay.lf
+++ b/test/Cpp/src/ActionDelay.lf
@@ -4,7 +4,7 @@ target Cpp;
 reactor GeneratedDelay {
     input y_in:int;
     output y_out:int;
-    state y_state:int(0);
+    state y_state: int{0};
     logical action act(100 msec):void;
     reaction(y_in) -> act {=
         y_state = *y_in.get();

--- a/test/Cpp/src/ArrayAsParameter.lf
+++ b/test/Cpp/src/ArrayAsParameter.lf
@@ -33,7 +33,7 @@ reactor Print {
     =}
 }
 main reactor ArrayAsParameter {
-    s = new Source(sequence(1, 2, 3, 4));
+    s = new Source(sequence{1, 2, 3, 4});
     p = new Print();
     s.out -> p.in;
 }

--- a/test/Cpp/src/ArrayAsParameter.lf
+++ b/test/Cpp/src/ArrayAsParameter.lf
@@ -1,9 +1,9 @@
 // Source has an variable sized list as a parameter, the elements of which it passes to Print.
 target Cpp;
 
-reactor Source(sequence:int[](0, 1, 2)) {
-    output out:int;
-    state count:int(0);
+reactor Source(sequence:int[]{0, 1, 2}) {
+    output out: size_t;
+    state count: size_t{0};
     logical action next:void;
     reaction(startup, next) -> out, next {=
         out.set(sequence[count]);
@@ -15,8 +15,8 @@ reactor Source(sequence:int[](0, 1, 2)) {
 }
 
 reactor Print {
-    input in:int;
-    state count:int(1);
+    input in: size_t;
+    state count: size_t{1};
     reaction(in) {=
         std::cout << "Received: " << *in.get() << '\n';
         if (*in.get() != count) {

--- a/test/Cpp/src/MovingAverage.lf
+++ b/test/Cpp/src/MovingAverage.lf
@@ -7,8 +7,8 @@ target Cpp {
     fast: true
 };
 reactor Source {
-    output out:double;
-    state count:int(0);
+    output out: double;
+    state count: int{0};
     timer clock(0, 200 msec);
     reaction(clock) -> out {=
         out.set(count);
@@ -16,8 +16,8 @@ reactor Source {
     =}
 }
 reactor MovingAverageImpl {
-    state delay_line:double[3](0.0, 0.0, 0.0);
-    state index:int(0);
+    state delay_line: double[3] {0.0, 0.0, 0.0};
+    state index: int{0};
     input in:double;
     output out:double;
 
@@ -42,7 +42,7 @@ reactor MovingAverageImpl {
 
 reactor Print {
     input in:double;
-    state count:int(0);
+    state count: int{0};
     reaction(in) {=
         std::cout << "Received: " << *in.get() << '\n';
         constexpr double expected[6] = {0.0, 0.25, 0.75, 1.5, 2.5, 3.5};

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -5,10 +5,10 @@ target Cpp;
 reactor Foo(x:int(0), 
 			y:time(0), 		// Units are missing but not required
 			z(1 msec), 		// Type is missing but not required
-			p:int[](1, 2, 3, 4),		// List of integers 
-			q:{=std::vector<reactor::Duration>=}(1 msec, 2 msec, 3 msec), // list of time values
+			p:int[]{1, 2, 3, 4},		// List of integers 
+			q:{=std::vector<reactor::Duration>=}{1 msec, 2 msec, 3 msec}, // list of time values
 			r:time({=0=}),	// Zero-valued target code also is a valid time
-			g:time[](1 msec, 2 msec)	// List of time values
+			g:time[]{1 msec, 2 msec}	// List of time values
 			) {
 	state s:time(y);	// Reference to explicitly typed time parameter
 	state t:time(z);	// Reference to implicitly typed time parameter

--- a/test/Cpp/src/NativeListsAndTimes.lf
+++ b/test/Cpp/src/NativeListsAndTimes.lf
@@ -19,6 +19,7 @@ reactor Foo(x:int(0),
 	timer toe(z);		// Implicit type time
 	state baz(p);		// Implicit type int[]
 	state period(z);	// Implicit type time
+	state times: std::vector<std::vector<{=reactor::Duration=}>>{q, g}; // a list of lists
 	reaction(tick) {=
 		// Target code	
 	=}

--- a/test/Cpp/src/StructAsState.lf
+++ b/test/Cpp/src/StructAsState.lf
@@ -7,11 +7,11 @@ public preamble {=
 =}
 
 main reactor StructAsState {
-    state s:Hello("Earth", 42);
+    state s: Hello{"Earth", 42};
     reaction(startup) {=
-        std::cout << "State s.name=" << s.name << ", self->s.name" << s.value << '\n';
+        std::cout << "State s.name=" << s.name << ", s.value=" << s.value << '\n';
         if (s.value != 42 && s.name != "Earth") {
-            std::cerr << "ERROR: Expected 42 and Erath!\n";
+            std::cerr << "ERROR: Expected 42 and Earth!\n";
             exit(1);
         }
     =}

--- a/test/Cpp/src/target/BraceAndParenInitialization.lf
+++ b/test/Cpp/src/target/BraceAndParenInitialization.lf
@@ -1,0 +1,28 @@
+target Cpp;
+
+reactor Foo(
+    param_list_1: std::vector<int>(4, 2), // list containing [2,2,2,2]
+    param_list_2: std::vector<int>{4, 2}, // list containing [4,2]
+    param_list_3: std::vector<int>(4, 2), // list containing [2,2,2,2]
+    param_list_4: std::vector<int>{4, 2}  // list containing [4,2]
+) {
+    state state_list_1: std::vector<int>(6,42); // list containing [42,42,42,42,42,42]
+    state state_list_2: std::vector<int>{6,42}; // list containing [6,42]
+
+    reaction(startup) {=
+            std::cerr << "Hello!\n";
+        if (param_list_1.size() != 4 || param_list_1[0] != 2 ||
+            param_list_2.size() != 2 || param_list_2[0] != 4 ||
+            param_list_3.size() != 3 || param_list_3[0] != 5 ||
+            param_list_4.size() != 2 || param_list_4[0] != 3 ||
+            state_list_1.size() != 6 || state_list_1[0] != 42 ||
+            state_list_2.size() != 2 || state_list_2[0] != 6) {
+            std::cerr << "Error!\n";
+            exit(1);
+        }
+    =}
+}
+
+main reactor {
+    foo = new Foo(param_list_3(3,5), param_list_4{3,5});
+}


### PR DESCRIPTION
Essentially, this MR extends the grammar to allow `{...}` for initializing state variables and parameters as an alternative to the current `(...)` syntax. The validator ensures that this feature is only usable in the C++ target. See below for a more detailed explanation.

There is a semantic difference in C++ between brace based initialization `{...}` and parenthesis based initialization `(...)`. Generally speaking, the curly braces should be preferred _whenever possible_. I don't want to go into the details of this, but if you are interested, [here](https://stackoverflow.com/questions/18222926/why-is-list-initialization-using-curly-braces-better-than-the-alternatives) is a discussion on stackoverflow. Now in my opinion C++ has messed up quite a bit, because it is not at all clear when it is possible to use the curly braces for initialization. The current policy in the LF C++ code generator is to _always_ use the curly braces for initialization. This works well for simple examples, but causes problems in more complex scenarios, as curly braces can be ambiguous in C++ code...

Let me make an example to illustrate the problem. Consider this state variable:
```
state foo: std::vector<int>(4,2);
```
This variable will be initialized in the constructor of the generated reactor. In C++ we have two options for this initialization: `foo(4,2)` or `foo{4,2}`. Both will do very different things! `foo(4,2)` calls the [vector constructor 3)](https://en.cppreference.com/w/cpp/container/vector/vector) which "_3) Constructs the container with count copies of elements with value value_". So the resulting vector will be initialized to `[2, 2, 2, 2]`. However, if we use the curly braces, a different constructor will be called as the braces are interpreted as an initializer list: "_10) Constructs the container with the contents of the initializer list init._". Thus, the resulting vector will be set to `[4, 2]`. This is equivalent to calling `foo({4, 2})`.

Since the current policy in the LF C++ code generator is to always use curly braces, it is impossible to call a `std::vector` constructor other than the initializer list one. This is also a problem for many other classes. Now we could switch policies and always generate parenthesis based initializers. However, the curly braces have significant advantages over parenthesis, and it would be nice if we are able to use them where it is appropriate. Therefore, this MR introduces the `{...}` syntax and gives the LF programmer full control over the initialization method to be used in the generated code.



