### PR TITLE
Fix compile errors in MQTT example.

### DIFF
--- a/example/C/src/MQTT/MQTTDistributed.lf
+++ b/example/C/src/MQTT/MQTTDistributed.lf
@@ -63,7 +63,7 @@
  */
 target C {
     threads: 1, // Must use threaded implementation so schedule is thread safe.
-    flags: "-I/usr/local/include -L/usr/local/lib -g -lpaho-mqtt3c",
+    flags: "-lpaho-mqtt3c",
     timeout: 10 secs,
     keepalive: true
 };

--- a/example/C/src/MQTT/MQTTPublisher.lf
+++ b/example/C/src/MQTT/MQTTPublisher.lf
@@ -5,7 +5,9 @@
  * @author Ravi Akella
  * @author Edward A. Lee
  */
-target C;
+target C {
+    threads: 1  // This makes sure pthreads is included and gives access to the mutex.
+};
 
 /**
  * Reactor that publishes strings to a specified MQTT topic.
@@ -42,6 +44,7 @@ reactor MQTTPublisher (
     preamble {=
         #include "MQTTClient.h"
         #include "core/net_util.h"
+        #include <pthread.h>
         
         // Timeout for completion of message sending in milliseconds.
         #define TIMEOUT     10000L

--- a/example/C/src/MQTT/MQTTPublisher.lf
+++ b/example/C/src/MQTT/MQTTPublisher.lf
@@ -142,7 +142,7 @@ reactor MQTTPublisher (
         
         // Append the current timestamp to the message.
         // This is always last, after the physical timestamp if it is included.
-        encode_ll(get_logical_time(), 
+        encode_int64(get_logical_time(), 
             (unsigned char*)(self->inflight.message + length - sizeof(instant_t))
         );
         // printf("DEBUG: Timestamp of sending message: %lld.\n", *timestamp);
@@ -161,7 +161,7 @@ reactor MQTTPublisher (
         // As close as possible to the publishing of the message, insert
         // the physical timestamp if it has been requested.
         if (self->include_physical_timestamp) {
-            encode_ll(get_physical_time(),
+            encode_int64(get_physical_time(),
                 (unsigned char*)(self->inflight.message + length - 2 * sizeof(instant_t))
             );
         }        

--- a/example/C/src/MQTT/MQTTSubscriber.lf
+++ b/example/C/src/MQTT/MQTTSubscriber.lf
@@ -105,7 +105,7 @@ reactor MQTTSubscriber (
             // locks held by the current thread when waiting for signals.
             pthread_mutex_lock(&mutex);
             
-            instant_t timestamp = extract_ll((unsigned char*)message->payload + message->payloadlen - sizeof(instant_t));
+            instant_t timestamp = extract_int64((unsigned char*)message->payload + message->payloadlen - sizeof(instant_t));
             interval_t delay = timestamp - get_logical_time();
             // printf("DEBUG: MQTTSubscriber.message_arrived: received timestamp that is %lld ahead of current_time %lld.\n", *timestamp - start_time, current_time);
             // printf("DEBUG: MQTTSubscriber.message_arrived: physical time is ahead of current logical time by: %lld.\n", receive_physical_time - current_time);
@@ -232,7 +232,7 @@ reactor MQTTSubscriber (
         size_t string_length = strlen(incoming_message->value); // Assumes null-terminated string.
         if (incoming_message->token->length == string_length + 1 + 2*sizeof(instant_t)) {
             instant_t receive_physical_time = get_physical_time();
-            instant_t physical_timestamp = extract_ll((unsigned char*)(incoming_message->value + string_length + 1));
+            instant_t physical_timestamp = extract_int64((unsigned char*)(incoming_message->value + string_length + 1));
             latency = receive_physical_time - physical_timestamp;
             // printf("DEBUG: MQTTReceiver.reaction: Reacted to message after measured latency of %lld nsec (assuming synchronized clocks).\n", latency);
         }


### PR DESCRIPTION
This pull request is for fixing the compile errors of the MQTT C example.

Here are the three errors being fixed by this pull request:

1.  encode|extract_ll -> encode|extract_int64:

```
Multiple markers at this line
- error: implicit declaration of function 'extract_ll' is invalid
   in C99 [-Werror,-Wimplicit-function-declaration]
    instant_t
   timestamp = extract_ll((unsigned char*)message->payload + message->payloadlen
   - sizeof(instant_t));
                          ^
- note: did you mean 'extract_tag'?
src-gen/MQTT/MQTTPhysical/core/net_util.h:280:7:
   note: 'extract_tag' declared here
tag_t extract_tag(
      ^
```

2. Error in MQTTPublisher.lf due to missing compilation options:

- Original error:

```
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTPublisher/MQTTPublisher.c -o bin/MQTTPublisher.o -O2 -c
In file included from file:/Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src/MQTT/MQTTPublisher.lf:44:
src-gen/MQTT/MQTTPublisher/core/net_util.h:108:3: error: unknown type name 'lf_mutex_t'
lf_mutex_t* mutex,
^
1 error generated.
Refreshed /CExamples
Refreshed /test
```

- Compilation command and output after this fix:

```
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTPublisher/MQTTPublisher.c -o bin/MQTTPublisher.o -pthread -DNUMBER_OF_WORKERS=1 -O2 -c
Refreshed /CExamples
Refreshed /test
```

3. Error in MQTTDistributed.lf due to (probably) out-of-sync compilation flags:

- Original error:

```
Generating code for: platform:/resource/CExamples/src/MQTT/MQTTDistributed.lf
******** mode: INTEGRATED
******** source file: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src/MQTT/MQTTDistributed.lf
******** generated sources: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed
******** generated binaries: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/bin
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_source.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_source -pthread -DNUMBER_OF_WORKERS=1 -I/usr/local/include -L/usr/local/lib -g -lpaho-mqtt3c
Undefined symbols for architecture x86_64:
"_MQTTClient_connect", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_create", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_destroy", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_2 in MQTTDistributed_source-e53091.o
"_MQTTClient_disconnect", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_2 in MQTTDistributed_source-e53091.o
"_MQTTClient_free", referenced from:
_message_arrived in MQTTDistributed_source-e53091.o
"_MQTTClient_freeMessage", referenced from:
_message_arrived in MQTTDistributed_source-e53091.o
"_MQTTClient_publishMessage", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_source-e53091.o
"_MQTTClient_setCallbacks", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_subscribe", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_waitForCompletion", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_source-e53091.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ERROR: Undefined symbols for architecture x86_64:
"_MQTTClient_connect", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_create", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_destroy", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_2 in MQTTDistributed_source-e53091.o
"_MQTTClient_disconnect", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_2 in MQTTDistributed_source-e53091.o
"_MQTTClient_free", referenced from:
_message_arrived in MQTTDistributed_source-e53091.o
"_MQTTClient_freeMessage", referenced from:
_message_arrived in MQTTDistributed_source-e53091.o
"_MQTTClient_publishMessage", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_source-e53091.o
"_MQTTClient_setCallbacks", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
_mqttpublisherreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_subscribe", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_source-e53091.o
"_MQTTClient_waitForCompletion", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_source-e53091.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_destination.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_destination -pthread -DNUMBER_OF_WORKERS=1 -I/usr/local/include -L/usr/local/lib -g -lpaho-mqtt3c
Undefined symbols for architecture x86_64:
"_MQTTClient_connect", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_create", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_destroy", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_2 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_disconnect", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_2 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_free", referenced from:
_message_arrived in MQTTDistributed_destination-eb5987.o
"_MQTTClient_freeMessage", referenced from:
_message_arrived in MQTTDistributed_destination-eb5987.o
"_MQTTClient_publishMessage", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_setCallbacks", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_subscribe", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_waitForCompletion", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_destination-eb5987.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ERROR: Undefined symbols for architecture x86_64:
"_MQTTClient_connect", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_create", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_destroy", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_2 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_disconnect", referenced from:
_mqttsubscriberreaction_function_2 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_2 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_free", referenced from:
_message_arrived in MQTTDistributed_destination-eb5987.o
"_MQTTClient_freeMessage", referenced from:
_message_arrived in MQTTDistributed_destination-eb5987.o
"_MQTTClient_publishMessage", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_setCallbacks", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
_mqttpublisherreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_subscribe", referenced from:
_mqttsubscriberreaction_function_0 in MQTTDistributed_destination-eb5987.o
"_MQTTClient_waitForCompletion", referenced from:
_mqttpublisherreaction_function_1 in MQTTDistributed_destination-eb5987.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

-  Compilation command and output after this fix:

```
******** source file: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src/MQTT/MQTTDistributed.lf
******** generated sources: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed
******** generated binaries: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/bin
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_source.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_source -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_destination.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_destination -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_RTI.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_RTI -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
Refreshed /CExamples
Refreshed /test
Generating code for: platform:/resource/CExamples/src/MQTT/MQTTDistributed.lf
******** mode: INTEGRATED
******** source file: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src/MQTT/MQTTDistributed.lf
******** generated sources: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed
******** generated binaries: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/bin
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_source.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_source -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_destination.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_destination -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
--- Looking for command gcc ... SUCCESS
--- Current working directory: /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C
--- Executing command: gcc src-gen/MQTT/MQTTDistributed/MQTTDistributed_RTI.c /Users/hokeunkim/Development/eclipses/lingua-franca-master/git/lingua-franca/example/C/src-gen/MQTT/MQTTDistributed/core/platform/lf_macos_support.c -o bin/MQTTDistributed_RTI -pthread -DNUMBER_OF_WORKERS=1 -lpaho-mqtt3c
Refreshed /CExamples
Refreshed /test
```