### PR TITLE
Redesign command handling

### DIFF
--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -1367,7 +1367,7 @@ class CGenerator extends GeneratorBase {
             if (federate.host !== null && federate.host != 'localhost' && federate.host != '0.0.0.0') {
                 if(distCode.length === 0) pr(distCode, distHeader)
                 val logFileName = '''log/«topLevelName»_«federate.name».log'''
-                val compileCommand = compileCCommand('''«topLevelName»_«federate.name»''', false).command.join(" ")
+                val compileCommand = compileCCommand('''«topLevelName»_«federate.name»''', false).toString()
                 //'''«targetConfig.compiler» src-gen/«topLevelName»_«federate.name».c -o bin/«topLevelName»_«federate.name» -pthread «targetConfig.compilerFlags.join(" ")»'''
                 // FIXME: Should $FEDERATION_ID be used to ensure unique directories, executables, on the remote host?
                 pr(distCode, '''
@@ -3256,16 +3256,15 @@ class CGenerator extends GeneratorBase {
      * @param filename Name of the file to process.
      */
      def processProtoFile(String filename) {
-        val protoc = createCommand(
+        val protoc = commandFactory.createCommand(
             "protoc-c",
             #['''--c_out=«this.fileConfig.getSrcGenPath»''', filename],
-            fileConfig.srcPath,
-            "Processing .proto files requires proto-c >= 1.3.3.",
-            true)
+            fileConfig.srcPath)
         if (protoc === null) {
+            errorReporter.reportError("Processing .proto files requires proto-c >= 1.3.3.")
             return
         }
-        val returnCode = protoc.executeCommand()
+        val returnCode = protoc.run()
         if (returnCode == 0) {
             val nameSansProto = filename.substring(0, filename.length - 6)
             targetConfig.compileAdditionalSources.add(this.fileConfig.getSrcGenPath.resolve(nameSansProto + ".pb-c.c").toString)

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -26,13 +26,10 @@
  ***************/
 package org.lflang.generator
 
-import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import java.io.OutputStream
 import java.nio.file.Files
-import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardCopyOption
 import java.util.LinkedHashMap
@@ -133,6 +130,11 @@ abstract class GeneratorBase extends AbstractLFValidator {
      * The current file configuration.
      */
     protected var FileConfig fileConfig
+    
+    /**
+     * A factory for compiler commands.
+     */
+    protected var GeneratorCommandFactory commandFactory   
 
     /**
      * Collection of generated delay classes.
@@ -249,19 +251,6 @@ abstract class GeneratorBase extends AbstractLFValidator {
      * Map from builder to its current indentation.
      */
     var indentation = new LinkedHashMap<StringBuilder, String>()
-
-    /**
-     * Defines the execution environment that is used to execute binaries.
-     * 
-     * A given command may be directly executable on the host (NATIVE) 
-     * or it may need to be executed within a bash shell (BASH). 
-     * On Unix-like machines, this is typically determined by the PATH variable
-     * which could be different in these two environments.
-     */
-    enum ExecutionEnvironment {
-        NATIVE,
-        BASH
-    }
     
     /**
      * Create a new GeneratorBase object.
@@ -270,6 +259,7 @@ abstract class GeneratorBase extends AbstractLFValidator {
         this.fileConfig = fileConfig
         this.topLevelName = fileConfig.name
         this.errorReporter = errorReporter
+        this.commandFactory = new GeneratorCommandFactory(errorReporter, fileConfig)
     }
 
     // //////////////////////////////////////////
@@ -713,16 +703,15 @@ abstract class GeneratorBase extends AbstractLFValidator {
             return false
         }
 
-        val stderr = new ByteArrayOutputStream()
-        val returnCode = compile.executeCommand(stderr)
+        val returnCode = compile.run()
 
         if (returnCode != 0 && fileConfig.compilerMode !== Mode.INTEGRATED) {
             errorReporter.reportError('''«targetConfig.compiler» returns error code «returnCode»''')
         }
         // For warnings (vs. errors), the return code is 0.
         // But we still want to mark the IDE.
-        if (stderr.toString.length > 0 && fileConfig.compilerMode === Mode.INTEGRATED) {
-            reportCommandErrors(stderr.toString())
+        if (compile.errors.toString.length > 0 && fileConfig.compilerMode === Mode.INTEGRATED) {
+            reportCommandErrors(compile.errors.toString())
         }
         return (returnCode == 0)
     }
@@ -744,12 +733,10 @@ abstract class GeneratorBase extends AbstractLFValidator {
         for (cmd : targetConfig.buildCommands) {
             val tokens = newArrayList(cmd.split("\\s+"))
             if (tokens.size > 0) {
-                val buildCommand = createCommand(
+                val buildCommand = commandFactory.createCommand(
                     tokens.head,
                     tokens.tail.toList,
-                    this.fileConfig.srcPath,
-                    "Executing user specified build command " + cmd + " failed.",
-                    true
+                    this.fileConfig.srcPath
                 )
                 // If the build command could not be found, abort.
                 // An error has already been reported in createCommand.
@@ -761,8 +748,8 @@ abstract class GeneratorBase extends AbstractLFValidator {
         }
 
         for (cmd : commands) {
-            val stderr = new ByteArrayOutputStream()
-            val returnCode = cmd.executeCommand(stderr)
+            // execute the command
+            val returnCode = cmd.run()
 
             if (returnCode != 0 && fileConfig.compilerMode !== Mode.INTEGRATED) {
                 errorReporter.reportError('''Build command "«targetConfig.buildCommands»" returns error code «returnCode»''')
@@ -770,8 +757,8 @@ abstract class GeneratorBase extends AbstractLFValidator {
             }
             // For warnings (vs. errors), the return code is 0.
             // But we still want to mark the IDE.
-            if (stderr.toString.length > 0 && fileConfig.compilerMode === Mode.INTEGRATED) {
-                reportCommandErrors(stderr.toString())
+            if (cmd.errors.toString.length > 0 && fileConfig.compilerMode === Mode.INTEGRATED) {
+                reportCommandErrors(cmd.errors.toString())
                 return
             }
         }
@@ -789,13 +776,6 @@ abstract class GeneratorBase extends AbstractLFValidator {
      *  will never have a `-c` flag.
      */
     protected def compileCCommand(String fileToCompile, boolean doNotLinkIfNoMain) {
-        val env = findCommandEnv(
-            targetConfig.compiler, 
-            "The C target requires GCC >= 7 to compile the generated code. " +
-            "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-            true
-        )
-        
         val cFilename = getTargetFileName(fileToCompile);
 
         var relativeSrcPath = fileConfig.outPath.relativize(
@@ -849,7 +829,14 @@ abstract class GeneratorBase extends AbstractLFValidator {
                 errorReporter.reportError("ERROR: Did not output executable; no main reactor found.")
             }
         }
-        return createCommand(targetConfig.compiler,compileArgs, fileConfig.outPath, env)
+        
+        val command = commandFactory.createCommand(targetConfig.compiler, compileArgs, fileConfig.outPath)
+        if (command === null) {
+            errorReporter.reportError(
+                "The C target requires GCC >= 7 to compile the generated code. " +
+                "Auto-compiling can be disabled using the \"no-compile: true\" target property.")
+        }
+        return command
     }
 
     // //////////////////////////////////////////
@@ -864,297 +851,6 @@ abstract class GeneratorBase extends AbstractLFValidator {
      */
     protected def clearCode() {
         code = new StringBuilder
-    }
-
-    /**
-     * Run a given command and record its output.
-     * 
-     * @param cmd the command to be executed
-     * @param errStream a stream object to forward the commands error messages to
-     * @param outStrram a stream object to forward the commands output messages to
-     * @return the commands return code
-     */
-    protected def executeCommand(ProcessBuilder cmd, OutputStream errStream, OutputStream outStream) {
-        println('''--- Current working directory: «cmd.directory.toString()»''')
-        println('''--- Executing command: «cmd.command.join(" ")»''')
-
-        var List<OutputStream> outStreams = newArrayList
-        var List<OutputStream> errStreams = newArrayList
-        outStreams.add(System.out)
-        errStreams.add(System.err)
-        if (outStream !== null) {
-            outStreams.add(outStream)
-        }
-        if (errStream !== null) {
-            errStreams.add(errStream)
-        }
-
-        // Execute the command. Write output to the System output,
-        // but also keep copies in outStream and errStream
-        return cmd.runSubprocess(outStreams, errStreams)
-    }
-
-    /**
-     * Run a given command and discard its standard and error output.
-     * 
-     * @param cmd the command to be executed
-     * @return the commands return code
-     */
-    protected def executeCommand(ProcessBuilder cmd) {
-        return cmd.executeCommand(null, null)
-    }
-
-    /**
-     * Run a given command and capture its error output.
-     * 
-     * @param cmd the command to be executed
-     * @param errStream a stream object to forward the commands error messages to
-     * @return the commands return code
-     */
-    protected def executeCommand(ProcessBuilder cmd, OutputStream errStream) {
-        return cmd.executeCommand(errStream, null)
-    }
-
-    /**
-     * Create a ProcessBuilder for a given command.
-     * 
-     * This method makes sure that the given command is executable,
-     * It first tries to find the command with 'which cmake'. If that
-     * fails, it tries again with bash. In case this fails again,
-     * it returns null. Otherwise, a correctly constructed ProcessBuilder
-     * object is returned. 
-     * 
-     * This command creates the following environment variables in the returned
-     * ProcessBuilder:
-     * 
-     * * LF_CURRENT_WORKING_DIRECTORY: The directory in which the command is invoked.
-     * * LF_SOURCE_DIRECTORY: The directory containing the .lf file being compiled.
-     * * LF_SOURCE_GEN_DIRECTORY: The directory in which generated files are placed.
-     * * LF_BIN_DIRECTORY: The directory into which to put binaries.
-     * 
-     * A bit more context:
-     * If the command cannot be found directly, then a second attempt is made using a
-     * Bash shell with the --login option, which sources the user's 
-     * ~/.bash_profile, ~/.bash_login, or ~/.bashrc (whichever
-     * is first found) before running the command. This helps to ensure that
-     * the user's PATH variable is set according to their usual environment,
-     * assuming that they use a bash shell.
-     * 
-     * More information: Unfortunately, at least on a Mac if you are running
-     * within Eclipse, the PATH variable is extremely limited; supposedly, it
-     * is given by the default provided in /etc/paths, but at least on my machine,
-     * it does not even include directories in that file for some reason.
-     * One way to add a directory like
-     * /usr/local/bin to the path once-and-for-all is this:
-     * 
-     * sudo launchctl config user path /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
-     * 
-     * But asking users to do that is not ideal. Hence, we try a more hack-y
-     * approach of just trying to execute using a bash shell.
-     * Also note that while ProcessBuilder can configured to use custom
-     * environment variables, these variables do not affect the command that is
-     * to be executed but merely the environment in which the command executes.
-     * 
-     * @param cmd The command to be executed
-     * @param errorStringIfNotFound A message to be printed when the command was not found.
-     * @param failError Indicate whether to report a failure to find the command as an error (true) or a warning (false).
-     * @return A ProcessBuilder object if the command was found or null otherwise.
-     */
-    protected def createCommand(String cmd, String messageIfNotFound, boolean failError) {
-        return createCommand(
-            cmd,
-            #[],
-            fileConfig.outPath,
-            findCommandEnv(cmd, messageIfNotFound, failError)
-        ) // FIXME: add argument to specify where to execute; there is no useful assumption that would work here
-    }
-
-    /** 
-     * Try to find the command with 'which <cmd>' (or 'where <cmd>' on Windows). 
-     * If that fails, try again with bash, thereby using any PATH set in the 
-     * bash profile. If this fails again, report an error and return null.
-     * If the command has the form "./name", where
-     * name is an executable file in the current working directory,
-     * then that command will be used.
-     * 
-     * This returns ExecutionEnvironment.NATIVE 
-     * if the specified command is directly executable on the current host
-     * and ExecutionEnvironment.BASH 
-     * if the command must be executed within a bash shell.
-     * The latter occurs, for example, if the specified command 
-     * is not in the native path but is in the path
-     * specified by the user's bash configuration file.
-     * If the specified command is not found in either the native environment 
-     * nor the bash environment, then this reports and error and returns null.
-     * 
-     * @param cmd The command to find.
-     * @param dir A directory from which to search for the command or null to use PWD.
-     * @param messageIfNotFound A message to be printed when the command environment
-     *  was not found.
-     * @param failError Indicate whether to report a failure to find the command as an error (true) or a warning (false).
-     * @return Returns either ExecutionEnvironment.NATIVE or ExecutionEnvironment.BASH,
-     *  where ExecutionEnvironment is an enum.
-     * 
-     * @see findCommandEnv(String, Path)
-     */
-    protected def findCommandEnv(String cmd, String messageIfNotFound, boolean failError) {
-        return findCommandEnv(cmd, null, messageIfNotFound, failError)
-    }
-
-    /** 
-     * Try to find the command with 'which <cmd>' (or 'where <cmd>' on Windows). 
-     * If that fails, try again with bash, thereby using any PATH set in the 
-     * bash profile. If this fails again, report an error and return null.
-     * If a directory is given and the command has the form "./name", where
-     * name is an executable file in the specified directory,
-     * then that command will be used.
-     * 
-     * This returns ExecutionEnvironment.NATIVE 
-     * if the specified command is directly executable on the current host
-     * and ExecutionEnvironment.BASH 
-     * if the command must be executed within a bash shell.
-     * The latter occurs, for example, if the specified command 
-     * is not in the native path but is in the path
-     * specified by the user's bash configuration file.
-     * If the specified command is not found in either the native environment 
-     * nor the bash environment, then this reports and error and returns null.
-     * 
-     * @param cmd The command to find.
-     * @param dir A directory from which to search for the command or null to use PWD.
-     * @param errorStringIfNotFound An error mesasge to be printed when the command environment
-     *  was not found.
-     * 
-     * @return Returns either ExecutionEnvironment.NATIVE or ExecutionEnvironment.BASH,
-     *  where ExecutionEnvironment is an enum.
-     */
-    protected def findCommandEnv(String cmd, Path dir, String messageIfNotFound, boolean failError) {
-        // Make sure the command is found in the PATH.
-        print('''--- Looking for command «cmd» ... ''')
-        // Use 'where' on Windows, 'which' on other systems
-        val which = System.getProperty("os.name").startsWith("Windows") ? "where" : "which"
-        val whichBuilder = new ProcessBuilder(#[which, cmd])
-        if (dir !== null) {
-            val dirFile = new File(dir.toString)
-            if (dirFile.isDirectory()) {
-                whichBuilder.directory(dirFile)
-            }
-        }
-        val whichReturn = whichBuilder.start().waitFor()
-        if (whichReturn == 0) {
-            println("SUCCESS")
-
-            return ExecutionEnvironment.NATIVE
-        }
-        println("FAILED")
-        // Try running with bash.
-        // The --login option forces bash to look for and load the first of
-        // ~/.bash_profile, ~/.bash_login, and ~/.bashrc that it finds.
-        print('''--- Trying again with bash ... ''')
-        val bashCommand = #["bash", "--login", "-c", '''which «cmd»''']
-        val bashBuilder = new ProcessBuilder(bashCommand)
-        val bashOut = new ByteArrayOutputStream()
-        val bashReturn = bashBuilder.runSubprocess(#[bashOut], #[])
-        if (bashReturn == 0) {
-            println("SUCCESS")
-            return ExecutionEnvironment.BASH
-        }
-        if (failError) {
-            errorReporter.reportError( 
-            "The command " + cmd + " could not be found.\n" +
-                "Make sure that your PATH variable includes the directory where " + cmd + " is installed.\n" +
-                "You can set PATH in ~/.bash_profile on Linux or Mac.\n" + messageIfNotFound)
-        } else {
-            errorReporter.reportWarning( 
-            "The command " + cmd + " could not be found.\n" +
-                "Make sure that your PATH variable includes the directory where " + cmd + " is installed.\n" +
-                "You can set PATH in ~/.bash_profile on Linux or Mac.\n" + messageIfNotFound)
-        }
-        
-        return null as ExecutionEnvironment
-    }
-
-    /**
-     * Create a ProcessBuilder for a given command and its arguments.
-     * If the env argument is ExecutionEnvironment.BASH, then the returned execution
-     * environment will be set up to run the command within bash.
-     * If the env argument is null, then report an error and return null.
-     * 
-     * This command creates the following environment variables in the returned
-     * ProcessBuilder:
-     * 
-     * * LF_CURRENT_WORKING_DIRECTORY: The directory in which the command is invoked.
-     * * LF_SOURCE_DIRECTORY: The directory containing the .lf file being compiled.
-     * * LF_SOURCE_GEN_DIRECTORY: The directory in which generated files are placed.
-     * * LF_BIN_DIRECTORY: The directory into which to put binaries.
-     * 
-     * @param cmd The command to be executed.
-     * @param args A list of arguments for the given command.
-     * @param dir The directory to change into before executing the command.
-     * @param env The type of the Execution Environment.
-     * 
-     * @return A ProcessBuilder object if the command was found or null otherwise.
-     */
-    protected def createCommand(String cmd, List<String> args, Path dir, ExecutionEnvironment env) {
-        var builder = null as ProcessBuilder
-        if (env == ExecutionEnvironment.NATIVE) {
-            builder = new ProcessBuilder(#[cmd] + args)
-            builder.directory(dir.toFile)
-        } else if (env == ExecutionEnvironment.BASH) {
-
-            val str_builder = new StringBuilder(cmd + " ")
-            for (str : args) {
-                str_builder.append(str + " ")
-            }
-            val bash_arg = str_builder.toString
-            // val bash_arg = #[cmd + args]
-            val newCmd = #["bash", "--login", "-c"]
-            // use that command to build the process
-            builder = new ProcessBuilder(newCmd + #[bash_arg])
-            builder.directory(dir.toFile)
-        } else {
-            println("FAILED")
-            errorReporter.reportError(
-                    "Was not able to determine an execution environment that contains " + cmd + ".")
-        }
-        // Set environment variables.
-        val environment = builder.environment();
-        environment.put("LF_CURRENT_WORKING_DIRECTORY", dir.toString());
-        environment.put("LF_SOURCE_DIRECTORY", fileConfig.srcPath.toString());
-        environment.put("LF_SOURCE_GEN_DIRECTORY", fileConfig.srcGenPath.toString());
-        environment.put("LF_BIN_DIRECTORY", fileConfig.binPath.toString());
-        return builder
-    }
-
-    /**
-     * Creates a ProcessBuilder for a given command and its arguments.
-     * If the specified command must be executed in a bash shell (i.e., if it cannot
-     * be found without the settings in your bash profile), then the returned execution
-     * environment will be set up to run the command within bash.
-     * If the command cannot be found, then report an error and return null.
-     * 
-     * This command creates the following environment variables in the returned
-     * ProcessBuilder:
-     * 
-     * * LF_CURRENT_WORKING_DIRECTORY: The directory in which the command is invoked.
-     * * LF_SOURCE_DIRECTORY: The directory containing the .lf file being compiled.
-     * * LF_SOURCE_GEN_DIRECTORY: The directory in which generated files are placed.
-     * * LF_BIN_DIRECTORY: The directory into which to put binaries.
-     * 
-     * @param cmd The command to be executed.
-     * @param args A list of arguments for the given command.
-     * @param dir A directory to change into before finding the command.
-     * @param messageIfNotFound An message to be printed when the command environment
-     *  was not found.
-     * @param failError Indicate whether to report a failure to find the command as an error (true) or a warning (false).
-     * @return A ProcessBuilder object if the command was found or null otherwise.
-     */
-    protected def createCommand(String cmd, List<String> args, Path dir, String messageIfNotFound, boolean failError) {
-        val env = findCommandEnv(cmd, dir, messageIfNotFound, failError)
-        if (env === null) {
-            // Could not find a suitable execution environment for 'cmd'
-            return null;
-        }
-        return createCommand(cmd, args, dir, env)
     }
 
     /**
@@ -2094,54 +1790,6 @@ abstract class GeneratorBase extends AbstractLFValidator {
         println('******** mode: ' + fileConfig.compilerMode)
         println('******** source file: ' + fileConfig.srcFile) // FIXME: redundant
         println('******** generated sources: ' + fileConfig.getSrcGenPath)
-    }
-
-    /**
-     * Execute a process while forwarding output and error streams.
-     * 
-     * Executing a process directly with `processBuiler.start()` could
-     * lead to a deadlock as the subprocess blocks when output or error
-     * buffers are full. This method ensures that output and error messages
-     * are continuously read and forwards them to the given streams.
-     * 
-     * @param processBuilder The process to be executed.
-     * @param outStream The stream to forward the process' output to.
-     * @param errStream The stream to forward the process' error messages to.
-     * @author{Christian Menard <christian.menard@tu-dresden.de}
-     */
-    private def runSubprocess(ProcessBuilder processBuilder, List<OutputStream> outStream,
-        List<OutputStream> errStream) {
-        val process = processBuilder.start()
-
-        var outThread = new Thread([|
-            var buffer = newByteArrayOfSize(64)
-            var len = process.getInputStream().read(buffer)
-            while (len != -1) {
-                for (os : outStream) {
-                    os.write(buffer, 0, len)
-                }
-                len = process.getInputStream().read(buffer)
-            }
-        ])
-        outThread.start()
-
-        var errThread = new Thread([|
-            var buffer = newByteArrayOfSize(64)
-            var len = process.getErrorStream().read(buffer)
-            while (len != -1) {
-                for (es : errStream) {
-                    es.write(buffer, 0, len)
-                }
-                len = process.getErrorStream().read(buffer)
-            }
-        ])
-        errThread.start()
-
-        val returnCode = process.waitFor()
-        outThread.join()
-        errThread.join()
-
-        return returnCode
     }
 
     /**

--- a/org.lflang/src/org/lflang/generator/GeneratorCommandFactory.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorCommandFactory.java
@@ -1,0 +1,144 @@
+/*************
+ Copyright (c) 2021 TU Dresden
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************/
+
+package org.lflang.generator;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.lflang.ErrorReporter;
+import org.lflang.FileConfig;
+import org.lflang.util.LFCommand;
+
+/**
+ * A factory class responsible for creating commands for use by the LF code generators.
+ * <p>
+ * In addition to the basic functionality of LFCommand, this class additionally ensures that error messages (or
+ * optionally warnings) are shown when a command is not found and that certain environment variables are set (see
+ * {@link #createCommand(String, List, Path, Boolean)} createCommand}).
+ */
+public class GeneratorCommandFactory {
+
+    protected final ErrorReporter errorReporter;
+    protected final FileConfig fileConfig;
+
+
+    /**
+     * Constructor
+     */
+    public GeneratorCommandFactory(ErrorReporter errorReporter, FileConfig fileConfig) {
+        assert errorReporter != null && fileConfig != null;
+        this.errorReporter = errorReporter;
+        this.fileConfig = fileConfig;
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command and an argument list.
+     * <p>
+     * The command will be executed in the CWD and if the command cannot be found an error message is shown.
+     *
+     * @param cmd  the command to look up
+     * @param args a list of arguments
+     * @return an LFCommand object or null if the command could not be found
+     * @see #createCommand(String, List, Path, Boolean)
+     */
+    public LFCommand createCommand(String cmd, List<String> args) {
+        return createCommand(cmd, args, null, true);
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command, an argument list and a directory.
+     *
+     * @param cmd         the command to look up
+     * @param args        a list of arguments
+     * @param failOnError If true, an error is shown if the command cannot be found. Otherwise, only a warning is
+     *                    displayed.
+     * @return an LFCommand object or null if the command could not be found
+     * @see #createCommand(String, List, Path, Boolean)
+     */
+    public LFCommand createCommand(String cmd, List<String> args, Boolean failOnError) {
+        return createCommand(cmd, args, null, failOnError);
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * <p>
+     * The command will be executed in the CWD and if the command cannot be found an error message is shown.
+     *
+     * @param cmd  the command to look up
+     * @param args a list of arguments
+     * @param dir  the directory to execute the command in. If null, this will default to the CWD
+     * @return an LFCommand object or null if the command could not be found
+     * @see #createCommand(String, List, Path, Boolean)
+     */
+    public LFCommand createCommand(String cmd, List<String> args, Path dir) {
+        return createCommand(cmd, args, dir, true);
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * <p>
+     * This will check first if the command can actually be found and executed. If the command is not found, null is
+     * returned. In addition, an error message will be shown if failOnError is true. Otherwise, a warning will be
+     * displayed.
+     *
+     * @param cmd         the command to look up
+     * @param args        a list of arguments
+     * @param dir         the directory to execute the command in. If null, this will default to the CWD
+     * @param failOnError If true, an error is shown if the command cannot be found. Otherwise, only a warning is
+     *                    displayed.
+     * @return an LFCommand object or null if the command could not be found
+     * @see LFCommand#get(String, List, Path)
+     */
+    public LFCommand createCommand(String cmd, List<String> args, Path dir, Boolean failOnError) {
+        assert cmd != null && args != null;
+        if (dir == null) {
+            dir = Paths.get("");
+        }
+        LFCommand command = LFCommand.get(cmd, args, dir);
+        if (command != null) {
+            command.setEnvironmentVariable("LF_CURRENT_WORKING_DIRECTORY", dir.toString());
+            command.setEnvironmentVariable("LF_SOURCE_DIRECTORY", fileConfig.srcPath.toString());
+            command.setEnvironmentVariable("LF_SOURCE_GEN_DIRECTORY", fileConfig.getSrcGenPath().toString());
+            command.setEnvironmentVariable("LF_BIN_DIRECTORY", fileConfig.binPath.toString());
+        } else {
+            final String message =
+                "The command " + cmd + " could not be found in the current working directory or in your PATH. " +
+                    "Make sure that your PATH variable includes the directory where " + cmd + " is installed. " +
+                    "You can set PATH in ~/.bash_profile on Linux or Mac.";
+            if (failOnError) {
+                errorReporter.reportError(message);
+            } else {
+                errorReporter.reportWarning(message);
+            }
+        }
+
+        return command;
+    }
+}

--- a/org.lflang/src/org/lflang/generator/GeneratorCommandFactory.java
+++ b/org.lflang/src/org/lflang/generator/GeneratorCommandFactory.java
@@ -1,5 +1,6 @@
 /*************
- Copyright (c) 2021 TU Dresden
+ Copyright (c) 2019-2021 TU Dresden
+ Copyright (c) 2019-2021 UC Berkeley
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -56,7 +57,7 @@ public class GeneratorCommandFactory {
 
 
     /**
-     * Create a LFCommand instance form a given command and an argument list.
+     * Create a LFCommand instance from a given command and an argument list.
      * <p>
      * The command will be executed in the CWD and if the command cannot be found an error message is shown.
      *
@@ -71,7 +72,7 @@ public class GeneratorCommandFactory {
 
 
     /**
-     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * Create a LFCommand instance from a given command, an argument list and a directory.
      *
      * @param cmd         the command to look up
      * @param args        a list of arguments
@@ -86,7 +87,7 @@ public class GeneratorCommandFactory {
 
 
     /**
-     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * Create a LFCommand instance from a given command, an argument list and a directory.
      * <p>
      * The command will be executed in the CWD and if the command cannot be found an error message is shown.
      *
@@ -102,7 +103,7 @@ public class GeneratorCommandFactory {
 
 
     /**
-     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * Create a LFCommand instance from a given command, an argument list and a directory.
      * <p>
      * This will check first if the command can actually be found and executed. If the command is not found, null is
      * returned. In addition, an error message will be shown if failOnError is true. Otherwise, a warning will be

--- a/org.lflang/src/org/lflang/generator/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/PythonGenerator.xtend
@@ -785,37 +785,25 @@ class PythonGenerator extends CGenerator {
      * Execute the command that compiles and installs the current Python module
      */
     def pythonCompileCode() {
-        val compileCmd = createCommand(
-            '''python3''',
-            #["setup.py", "build"],
-            fileConfig.outPath,
-            "The Python target requires Python >= 3.6, pip >= 20.0.2, and setuptools >= 45.2.0-1 to compile the generated code. " +
-            "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-            true)
-        val installCmd = createCommand(
+        // if we found the compile command, we will also find the install command
+        val installCmd = commandFactory.createCommand(
             '''python3''',
             #["-m", "pip", "install", "--ignore-installed", "--force-reinstall", "--no-binary", ":all:", "--user", "."],
-            fileConfig.outPath,
-            "The Python target requires Python >= 3.6, pip >= 20.0.2, and setuptools >= 45.2.0-1 to compile the generated code. " +
-            "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-            true
-           )
-
-        compileCmd.directory(fileConfig.getSrcGenPath.toFile)
-        installCmd.directory(fileConfig.getSrcGenPath.toFile)
+            fileConfig.srcGenPath)
+               
+        if (installCmd === null) {
+            errorReporter.reportError(
+                "The Python target requires Python >= 3.6, pip >= 20.0.2, and setuptools >= 45.2.0-1 to compile the generated code. " +
+                "Auto-compiling can be disabled using the \"no-compile: true\" target property.")
+            return
+        }
 
         // Set compile time environment variables
-        val compileEnv = compileCmd.environment
-        compileEnv.put("CC", targetConfig.compiler) // Use gcc as the compiler
-        compileEnv.put("LDFLAGS", targetConfig.linkerFlags) // The linker complains about including pythontarget.h twice (once in the generated code and once in pythontarget.c)
+        installCmd.setEnvironmentVariable("CC", targetConfig.compiler) // Use gcc as the compiler
+        installCmd.setEnvironmentVariable("LDFLAGS", targetConfig.linkerFlags) // The linker complains about including pythontarget.h twice (once in the generated code and once in pythontarget.c)
         // To avoid this, we force the linker to allow multiple definitions. Duplicate names would still be caught by the 
         // compiler.
-        val installEnv = compileCmd.environment
-        installEnv.put("CC", targetConfig.compiler) // Use gcc as the compiler
-        installEnv.put("LDFLAGS", targetConfig.linkerFlags) // The linker complains about including pythontarget.h twice (once in the generated code and once in pythontarget.c)
-        // To avoid this, we force the linker to allow multiple definitions. Duplicate names would still be caught by the 
-        // compiler.
-        if (executeCommand(installCmd) == 0) {
+        if (installCmd.run() == 0) {
             println("Successfully installed python extension.")
         } else {
             errorReporter.reportError("Failed to install python extension.")
@@ -941,16 +929,15 @@ class PythonGenerator extends CGenerator {
      * @param filename Name of the file to process.
      */
     override processProtoFile(String filename) {
-         val protoc = createCommand(
+         val protoc = commandFactory.createCommand(
             "protoc",
             #['''--python_out=«this.fileConfig.getSrcGenPath»''', filename],
-            fileConfig.srcPath,
-            "Processing .proto files requires libprotoc >= 3.6.1", true)
+            fileConfig.srcPath)
          //val protoc = createCommand("protoc", #['''--python_out=src-gen/«topLevelName»''', topLevelName], codeGenConfig.outPath)
         if (protoc === null) {
-            return
+            errorReporter.reportError("Processing .proto files requires libprotoc >= 3.6.1")
         }
-        val returnCode = protoc.executeCommand()
+        val returnCode = protoc.run()
         if (returnCode == 0) {
             pythonRequiredModules.append(''', 'google-api-python-client' ''')
         } else {

--- a/org.lflang/src/org/lflang/generator/TypeScriptGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/TypeScriptGenerator.xtend
@@ -57,7 +57,6 @@ import org.lflang.lf.VarRef
 import org.lflang.lf.Variable
 
 import static extension org.lflang.ASTUtils.*
-import java.io.ByteArrayOutputStream
 
 /** Generator for TypeScript target.
  *
@@ -211,31 +210,37 @@ class TypeScriptGenerator extends GeneratorBase {
         this.initializeProjectConfiguration()
 
         
-        val pnpmInstall = createCommand(
+        val pnpmInstall = commandFactory.createCommand(
             "pnpm",
             #["install"],
             fileConfig.getSrcGenPkgPath,
-            "Falling back on npm. To prevent an accumulation of replicated dependencies, " +
-                "it is highly recommended to install pnpm globally (npm install -g pnpm).",
-            false
+            false // only produce a warning if command is not found
         )
 
-        val installErrors = new ByteArrayOutputStream()
         // Attempt to use pnpm, but fall back on npm if it is not available.
         if (pnpmInstall !== null) {
-            val ret = pnpmInstall.executeCommand(installErrors)
+            val ret = pnpmInstall.run()
             if (ret !== 0) {
                 errorReporter.reportError(resource.findTarget,
-                    "ERROR: pnpm install command failed: " + installErrors.toString)
+                    "ERROR: pnpm install command failed: " + pnpmInstall.errors.toString())
             }
         } else {
-            val npmInstall = createCommand("npm", #["install"], fileConfig.getSrcGenPkgPath,
-                "The TypeScript target requires npm >= 6.14.4. " +
+            errorReporter.reportWarning(
+                "Falling back on npm. To prevent an accumulation of replicated dependencies, " +
+                "it is highly recommended to install pnpm globally (npm install -g pnpm).")
+            val npmInstall = commandFactory.createCommand("npm", #["install"], fileConfig.getSrcGenPkgPath)
+            
+            if (npmInstall === null) {
+                errorReporter.reportError(
+                    "The TypeScript target requires npm >= 6.14.4. " +
                     "For installation instructions, see: https://www.npmjs.com/get-npm. \n" +
-                    "Auto-compiling can be disabled using the \"no-compile: true\" target property.", true)
-            if (npmInstall !== null && npmInstall.executeCommand(installErrors) !== 0) {
+                    "Auto-compiling can be disabled using the \"no-compile: true\" target property.")
+                return
+            }
+            
+            if (npmInstall.run() !== 0) {
                 errorReporter.reportError(resource.findTarget,
-                    "ERROR: npm install command failed: " + installErrors.toString)
+                    "ERROR: npm install command failed: " + npmInstall.errors.toString())
                 errorReporter.reportError(resource.findTarget, "ERROR: npm install command failed." +
                     "\nFor installation instructions, see: https://www.npmjs.com/get-npm")
                 return
@@ -260,19 +265,14 @@ class TypeScriptGenerator extends GeneratorBase {
                 "--js_out=import_style=commonjs,binary:"+tsOutPath,
                 "--ts_out=" + tsOutPath)
             protocArgs.addAll(targetConfig.protoFiles.fold(newLinkedList, [list, file | list.add(file); list]))
-            val protoc = createCommand(
-                "protoc",
-                protocArgs,
-                fileConfig.srcPath,
-                "Processing .proto files requires libprotoc >= 3.6.1",
-                true
-                )
+            val protoc = commandFactory.createCommand("protoc", protocArgs, fileConfig.srcPath)
                 
             if (protoc === null) {
+                errorReporter.reportError("Processing .proto files requires libprotoc >= 3.6.1")
                 return
             }
 
-            val returnCode = protoc.executeCommand()
+            val returnCode = protoc.run()
             if (returnCode == 0) {
                 // FIXME: this code makes no sense. It is removing 6 chars from a file with a 3-char extension
 //                val nameSansProto = fileConfig.name.substring(0, fileConfig.name.length - 6)
@@ -290,47 +290,38 @@ class TypeScriptGenerator extends GeneratorBase {
             println("No .proto files have been imported. Skipping protocol buffer compilation.")
         }
         
+        
+        val errorMessage = "The TypeScript target requires npm >= 6.14.1 to compile the generated code. " +
+            "Auto-compiling can be disabled using the \"no-compile: true\" target property." 
 
         // Invoke the compiler on the generated code.
         println("Type Checking")
-        val tsc = createCommand(
-            "npm",
-            #["run", "check-types"],
-            fileConfig.getSrcGenPkgPath,
-            findCommandEnv(
-                "npm",
-                "The TypeScript target requires npm >= 6.14.1 to compile the generated code. " +
-                "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-                true
-            )            
-        )
-        if (tsc !== null) {
-            if (tsc.executeCommand() == 0) {
-                // Babel will compile TypeScript to JS even if there are type errors
-                // so only run compilation if tsc found no problems.
-                //val babelPath = codeGenConfig.outPath + File.separator + "node_modules" + File.separator + ".bin" + File.separator + "babel"
-                // Working command  $./node_modules/.bin/babel src-gen --out-dir js --extensions '.ts,.tsx'
-                println("Compiling")
-                val babel = createCommand(
-                    "npm",
-                    #["run", "build"],
-                    fileConfig.getSrcGenPkgPath,
-                    "The TypeScript target requires npm >= 6.14.1 to compile the generated code. " +
-                    "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-                    true
-                )
-                //createCommand(babelPath, #["src", "--out-dir", "dist", "--extensions", ".ts", "--ignore", "**/*.d.ts"], codeGenConfig.outPath)
-                
-                if (babel !== null) {
-                    if (babel.executeCommand() == 0) {
-                        println("SUCCESS (compiling generated TypeScript code)")                
-                    } else {
-                        errorReporter.reportError("Compiler failed.")
-                    }   
-                }
-            } else {
-                errorReporter.reportError("Type checking failed.")
+        val tsc = commandFactory.createCommand("npm", #["run", "check-types"], fileConfig.getSrcGenPkgPath)
+        if (tsc === null) {
+            errorReporter.reportError(errorMessage);
+            return
+        }
+         
+        if (tsc.run() == 0) {
+            // Babel will compile TypeScript to JS even if there are type errors
+            // so only run compilation if tsc found no problems.
+            //val babelPath = codeGenConfig.outPath + File.separator + "node_modules" + File.separator + ".bin" + File.separator + "babel"
+            // Working command  $./node_modules/.bin/babel src-gen --out-dir js --extensions '.ts,.tsx'
+            println("Compiling")
+            val babel = commandFactory.createCommand("npm", #["run", "build"], fileConfig.getSrcGenPkgPath)
+            
+            if (babel === null) {
+                errorReporter.reportError(errorMessage);
+                return
             }
+                
+            if (babel.run() == 0) {
+                println("SUCCESS (compiling generated TypeScript code)")                
+            } else {
+                errorReporter.reportError("Compiler failed.")
+            }   
+        } else {
+            errorReporter.reportError("Type checking failed.")
         }
 
         // If this is a federated execution, generate C code for the RTI.

--- a/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppGenerator.kt
@@ -38,7 +38,11 @@ import org.lflang.scoping.LFGlobalScopeProvider
 import java.nio.file.Path
 import java.nio.file.Paths
 
-class CppGenerator(private val cppFileConfig: CppFileConfig, errorReporter: ErrorReporter, private val scopeProvider: LFGlobalScopeProvider) :
+class CppGenerator(
+    private val cppFileConfig: CppFileConfig,
+    errorReporter: ErrorReporter,
+    private val scopeProvider: LFGlobalScopeProvider
+) :
     GeneratorBase(cppFileConfig, errorReporter) {
 
     companion object {
@@ -130,47 +134,43 @@ class CppGenerator(private val cppFileConfig: CppFileConfig, errorReporter: Erro
 
         val cores = Runtime.getRuntime().availableProcessors()
 
-        val makeBuilder = createCommand(
+        val makeCommand = commandFactory.createCommand(
             "cmake",
             listOf(
                 "--build", ".", "--target", "install", "--parallel", cores.toString(), "--config",
                 targetConfig.cmakeBuildType?.toString() ?: "Release"
             ),
-            outPath, // FIXME: it doesn't make sense to provide a search path here, createCommand() should accept null
-            "The C++ target requires CMAKE >= 3.02 to compile the generated code. " +
-                    "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-            true
+            buildPath
         )
-        val cmakeBuilder = createCommand(
+
+        val cmakeCommand = commandFactory.createCommand(
             "cmake", listOf(
                 "-DCMAKE_INSTALL_PREFIX=${outPath.toUnixString()}",
                 "-DREACTOR_CPP_BUILD_DIR=${reactorCppPath.toUnixString()}",
                 "-DCMAKE_INSTALL_BINDIR=${outPath.relativize(fileConfig.binPath).toUnixString()}",
                 fileConfig.srcGenPath.toUnixString()
             ),
-            outPath, // FIXME: it doesn't make sense to provide a search path here, createCommand() should accept null
-            "The C++ target requires CMAKE >= 3.02 to compile the generated code" +
-                    "Auto-compiling can be disabled using the \"no-compile: true\" target property.",
-            true
+            buildPath
         )
-        if (makeBuilder == null || cmakeBuilder == null) {
+        if (makeCommand == null || cmakeCommand == null) {
+            errorReporter.reportError(
+                "The C++ target requires CMAKE >= 3.02 to compile the generated code. " +
+                        "Auto-compiling can be disabled using the \"no-compile: true\" target property."
+            )
             return
         }
 
         // prepare cmake
-        cmakeBuilder.directory(buildPath.toFile())
         if (targetConfig.compiler != null) {
-            val cmakeEnv = cmakeBuilder.environment()
-            cmakeEnv["CXX"] = targetConfig.compiler
+            cmakeCommand.setEnvironmentVariable("CXX", targetConfig.compiler)
         }
 
         // run cmake
-        val cmakeReturnCode = executeCommand(cmakeBuilder)
+        val cmakeReturnCode = cmakeCommand.run()
 
         if (cmakeReturnCode == 0) {
-            // If cmake succeeded, prepare and run make
-            makeBuilder.directory(buildPath.toFile())
-            val makeReturnCode = executeCommand(makeBuilder)
+            // If cmake succeeded, run make
+            val makeReturnCode = makeCommand.run()
 
             if (makeReturnCode == 0) {
                 println("SUCCESS (compiling generated C++ code)")

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -1,3 +1,27 @@
+/*************
+ Copyright (c) 2021 TU Dresaden
+
+ Redistribution and use in source and binary forms, with or without modification,
+ are permitted provided that the following conditions are met:
+
+ 1. Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+ 2. Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ ***************/
+
 package org.lflang.util;
 
 import java.io.ByteArrayOutputStream;
@@ -8,6 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An abstraction for an external command
@@ -144,6 +169,27 @@ public class LFCommand {
             e.printStackTrace();
             return -2;
         }
+    }
+
+
+    /**
+     * Add the given variables and their values to the command's environment.
+     *
+     * @param variables A map of variable names and their values
+     */
+    public void setEnvironmentVariables(Map<String, String> variables) {
+        processBuilder.environment().putAll(variables);
+    }
+
+
+    /**
+     * Add the given variable and its value tor the command's environment.
+     *
+     * @param variableName name of the variable to add
+     * @param value        the variable's value
+     */
+    public void setEnvironmentVariable(String variableName, String value) {
+        processBuilder.environment().put(variableName, value);
     }
 
 

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -1,5 +1,5 @@
 /*************
- Copyright (c) 2021 TU Dresaden
+ Copyright (c) 2021 TU Dresden
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -1,0 +1,252 @@
+package org.lflang.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An abstraction for an external command
+ * <p>
+ * This is a wrapper around ProcessBuilder which allows for a more convenient usage in our code base.
+ */
+public class LFCommand {
+
+    protected ProcessBuilder processBuilder;
+    protected Boolean didRun = false;
+    protected ByteArrayOutputStream output = new ByteArrayOutputStream();
+    protected ByteArrayOutputStream errors = new ByteArrayOutputStream();
+
+
+    /**
+     * Constructor
+     */
+    protected LFCommand(ProcessBuilder pb) { processBuilder = pb; }
+
+
+    /**
+     * Get the output collected during command execution
+     */
+    public OutputStream getOutput() { return output; }
+
+
+    /**
+     * Get the error output collected during command execution
+     */
+    public OutputStream getErrors() { return errors; }
+
+
+    /**
+     * A runnable that collects the output from a running process, prints it and stores it in the output stream
+     */
+    private class OutputCollector implements Runnable {
+
+        private final Process process;
+
+
+        OutputCollector(Process process) {
+            this.process = process;
+        }
+
+
+        @Override
+        public void run() {
+            byte[] buffer = new byte[64];
+            int len;
+            do {
+                try {
+                    len = process.getInputStream().read(buffer);
+                    output.write(buffer, 0, len);
+                    System.out.write(buffer, 0, len);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    break;
+                }
+            } while (len != -1);
+        }
+    }
+
+    /**
+     * A runnable that collects the error output from a running process, prints it and stores it in the output stream
+     */
+    private class ErrorCollector implements Runnable {
+
+        private final Process process;
+
+
+        ErrorCollector(Process process) {
+            this.process = process;
+        }
+
+
+        @Override
+        public void run() {
+            byte[] buffer = new byte[64];
+            int len;
+            do {
+                try {
+                    len = process.getErrorStream().read(buffer);
+                    errors.write(buffer, 0, len);
+                    System.err.write(buffer, 0, len);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    break;
+                }
+            } while (len != -1);
+        }
+    }
+
+
+    /**
+     * Execute the command while forwarding output and error streams.
+     * <p>
+     * Executing a process directly with `processBuiler.start()` could
+     * lead to a deadlock as the subprocess blocks when output or error
+     * buffers are full. This method ensures that output and error messages
+     * are continuously read and forwards them to the system output and
+     * error streams as well as to the output and error streams hold in
+     * this class.
+     *
+     * @return the process' return code
+     * @author {Christian Menard <christian.menard@tu-dresden.de}
+     */
+    public Integer run() {
+        assert !didRun;
+        didRun = true;
+
+        System.out.println("--- Current working directory: " + processBuilder.directory().toString());
+        System.out.println("--- Executing command: " + String.join(" ", processBuilder.command()));
+
+        final Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return -1;
+        }
+
+        final Thread collectOutputThread = new Thread(new OutputCollector(process));
+        final Thread collectErrorsThread = new Thread(new ErrorCollector(process));
+
+        collectOutputThread.start();
+        collectErrorsThread.start();
+
+        try {
+            final int returnCode = process.waitFor();
+            collectOutputThread.join();
+            collectErrorsThread.join();
+            return returnCode;
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+            return -2;
+        }
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command and argument list in the current working directory.
+     *
+     * @see #get(String, List, Path)
+     */
+    public static LFCommand get(final String cmd, final List<String> args) {
+        return get(cmd, args, Paths.get(""));
+    }
+
+
+    /**
+     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * <p>
+     * This will check first if the command can actually be found and executed. If the command is not found, null is
+     * returned. In order to find the command, different methods are applied in the following order:
+     * <p>
+     * 1. Check if the given command `cmd` is an executable file within `dir`.
+     * 2. If the above fails 'which <cmd>' (or 'where <cmd>' on Windows) is executed to see if the command is available
+     * on the PATH.
+     * 3. If both points above fail, a third attempt is started using bash to indirectly execute the command (see below
+     * for an explanation).
+     * <p>
+     * A bit more context:
+     * If the command cannot be found directly, then a second attempt is made using a Bash shell with the --login
+     * option, which sources the user's ~/.bash_profile, ~/.bash_login, or ~/.bashrc (whichever is first found) before
+     * running the command. This helps to ensure that the user's PATH variable is set according to their usual
+     * environment, assuming that they use a bash shell.
+     * <p>
+     * More information: Unfortunately, at least on a Mac if you are running within Eclipse, the PATH variable is
+     * extremely limited; supposedly, it is given by the default provided in /etc/paths, but at least on my machine, it
+     * does not even include directories in that file for some reason. One way to add a directory like /usr/local/bin
+     * to
+     * the path once-and-for-all is this:
+     * <p>
+     * sudo launchctl config user path /usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin
+     * <p>
+     * But asking users to do that is not ideal. Hence, we try a more hack-y approach of just trying to execute using a
+     * bash shell. Also note that while ProcessBuilder can configured to use custom environment variables, these
+     * variables do not affect the command that is to be executed but merely the environment in which the command
+     * executes.
+     *
+     * @param cmd  The command
+     * @param args A list of arguments to pass to the command
+     * @param dir  The directory in which the command should be executed
+     * @return Returns an LFCommand if the given command could be found or null otherwise.
+     */
+    public static LFCommand get(final String cmd, final List<String> args, final Path dir) {
+        assert cmd != null && args != null && dir != null;
+
+        // a list containing the command as first element and then all arguments
+        List<String> cmdList = new ArrayList<>();
+        cmdList.add(cmd);
+        cmdList.addAll(args);
+
+        // First, see if the command is a local executable file
+        final File cmdFile = dir.resolve(cmd).toFile();
+        if (cmdFile.exists() && cmdFile.canExecute()) {
+            final ProcessBuilder builder = new ProcessBuilder(cmdList);
+            builder.directory(dir.toFile());
+        } else if (checkIfCommandIsOnPath(cmd, dir)) {
+            final ProcessBuilder builder = new ProcessBuilder(cmdList);
+            builder.directory(dir.toFile());
+        } else if (checkIfCommandIsExecutableWithBash(cmd, dir)) {
+            final ProcessBuilder builder = new ProcessBuilder("bash", "--login", "-c", String.join(" ", cmdList));
+            builder.directory(dir.toFile());
+        }
+
+        return null;
+    }
+
+
+    private static Boolean checkIfCommandIsOnPath(final String command, final Path dir) {
+        final String whichCmd = System.getProperty("os.name").startsWith("Windows") ? "where" : "which";
+        final ProcessBuilder whichBuilder = new ProcessBuilder(List.of(whichCmd, command));
+        whichBuilder.directory(dir.toFile());
+        try {
+            int whichReturn = whichBuilder.start().waitFor();
+            return whichReturn == 0;
+        } catch (InterruptedException | IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+
+    private static Boolean checkIfCommandIsExecutableWithBash(final String command, final Path dir) {
+        // check first if bash is installed
+        if (!checkIfCommandIsOnPath("bash", dir)) {
+            return false;
+        }
+
+        // then try to find command with bash
+        final ProcessBuilder bashBuilder = new ProcessBuilder(List.of("bash", "--login", "-c", "which " + command));
+        bashBuilder.directory(dir.toFile());
+        try {
+            int bashReturn = bashBuilder.start().waitFor();
+            return bashReturn == 0;
+        } catch (InterruptedException | IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -253,17 +253,21 @@ public class LFCommand {
         cmdList.add(cmd);
         cmdList.addAll(args);
 
+        ProcessBuilder builder = null;
+
         // First, see if the command is a local executable file
         final File cmdFile = dir.resolve(cmd).toFile();
         if (cmdFile.exists() && cmdFile.canExecute()) {
-            final ProcessBuilder builder = new ProcessBuilder(cmdList);
-            builder.directory(dir.toFile());
+            builder = new ProcessBuilder(cmdList);
         } else if (checkIfCommandIsOnPath(cmd, dir)) {
-            final ProcessBuilder builder = new ProcessBuilder(cmdList);
-            builder.directory(dir.toFile());
+            builder = new ProcessBuilder(cmdList);
         } else if (checkIfCommandIsExecutableWithBash(cmd, dir)) {
-            final ProcessBuilder builder = new ProcessBuilder("bash", "--login", "-c", String.join(" ", cmdList));
+            builder = new ProcessBuilder("bash", "--login", "-c", String.join(" ", cmdList));
+        }
+
+        if (builder != null) {
             builder.directory(dir.toFile());
+            return new LFCommand(builder);
         }
 
         return null;

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -1,5 +1,6 @@
 /*************
- Copyright (c) 2021 TU Dresden
+ Copyright (c) 2019-2021 TU Dresden
+ Copyright (c) 2019-2021 UC Berkeley
 
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:
@@ -204,7 +205,7 @@ public class LFCommand {
 
 
     /**
-     * Create a LFCommand instance form a given command and argument list in the current working directory.
+     * Create a LFCommand instance from a given command and argument list in the current working directory.
      *
      * @see #get(String, List, Path)
      */
@@ -214,7 +215,7 @@ public class LFCommand {
 
 
     /**
-     * Create a LFCommand instance form a given command, an argument list and a directory.
+     * Create a LFCommand instance from a given command, an argument list and a directory.
      * <p>
      * This will check first if the command can actually be found and executed. If the command is not found, null is
      * returned. In order to find the command, different methods are applied in the following order:

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -66,6 +66,12 @@ public class LFCommand {
 
 
     /**
+     * Get a String representation of the stored command
+     */
+    public String toString() { return String.join(" ", processBuilder.command()); }
+
+
+    /**
      * A runnable that collects the output from a running process, prints it and stores it in the output stream
      */
     private class OutputCollector implements Runnable {

--- a/org.lflang/src/org/lflang/util/LFCommand.java
+++ b/org.lflang/src/org/lflang/util/LFCommand.java
@@ -91,8 +91,10 @@ public class LFCommand {
             do {
                 try {
                     len = process.getInputStream().read(buffer);
-                    output.write(buffer, 0, len);
-                    System.out.write(buffer, 0, len);
+                    if (len > 0) {
+                        output.write(buffer, 0, len);
+                        System.out.write(buffer, 0, len);
+                    }
                 } catch (IOException e) {
                     e.printStackTrace();
                     break;
@@ -121,8 +123,10 @@ public class LFCommand {
             do {
                 try {
                     len = process.getErrorStream().read(buffer);
-                    errors.write(buffer, 0, len);
-                    System.err.write(buffer, 0, len);
+                    if (len > 0) {
+                        errors.write(buffer, 0, len);
+                        System.err.write(buffer, 0, len);
+                    }
                 } catch (IOException e) {
                     e.printStackTrace();
                     break;


### PR DESCRIPTION
This PR factors the handling of commands out of `GeneratorBase`. At the same time, the code is significantly simplified and generalized. Basically, this PR introduces the class `LFCommand` as our own custom abstraction of commands. Note, that this abstraction is more general than the old `createCommand` method we used in `GeneratorBase`. This allows a more flexible use of commands outside the generators (for instance in the test framework). An additional factory class `GeneratorCommandFactory` can be used to create more specialized commands for use within the code generators.

Closes #361 