### PR TITLE
Made bank_index a proper parameter.

### DIFF
--- a/org.lflang/src/org/lflang/generator/CGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/CGenerator.xtend
@@ -1763,9 +1763,6 @@ class CGenerator extends GeneratorBase {
         // Extensions can add functionality to the CGenerator
         generateSelfStructExtension(body, decl, federate, constructorCode, destructorCode)
         
-        // Handle bank_index
-        pr(body, '''«targetBankIndexType» «targetBankIndex»;''');    
-        
         // Next handle parameters.
         generateParametersForReactor(body, reactor)
         
@@ -2060,12 +2057,6 @@ class CGenerator extends GeneratorBase {
      */
     def generateParametersForReactor(StringBuilder builder, Reactor reactor) {
         for (parameter : reactor.allParameters) {
-            // Check for targetBankIndex
-            // FIXME: for now throw a reserved error
-            if (parameter.name.equals(targetBankIndex)) {
-                errorReporter.reportError('''«targetBankIndex» is reserved.''')
-            }
-
             prSourceLineNumber(builder, parameter)
             pr(builder, parameter.getInferredType.targetType + ' ' + parameter.name + ';');
         }
@@ -2079,13 +2070,6 @@ class CGenerator extends GeneratorBase {
      */
     def generateStateVariablesForReactor(StringBuilder builder, Reactor reactor) {        
         for (stateVar : reactor.allStateVars) {            
-            // Check for targetBankIndex
-            // FIXME: for now throw a reserved error
-            if(stateVar.name.equals(targetBankIndex))
-            {
-                errorReporter.reportError('''«targetBankIndex» is reserved.''')
-            }
-            
             prSourceLineNumber(builder, stateVar)
             pr(builder, stateVar.getInferredType.targetType + ' ' + stateVar.name + ';');
         }
@@ -3600,17 +3584,9 @@ class CGenerator extends GeneratorBase {
             pr(initializeTriggerObjects, '''
                 «nameOfSelfStruct» = new_«reactorClass.name»();
             ''')
-            // Set the bankIndex for the reactor
-            pr(initializeTriggerObjectsEnd, '''
-                «nameOfSelfStruct»->«targetBankIndex» = «instance.bankIndex»;
-            ''')
         } else {
             pr(initializeTriggerObjects, '''
                 «structType»* «nameOfSelfStruct» = new_«reactorClass.name»();
-            ''')
-            // Set the bankIndex to zero
-            pr(initializeTriggerObjectsEnd, '''
-                «nameOfSelfStruct»->«targetBankIndex» = 0;
             ''')
         }
         

--- a/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
+++ b/org.lflang/src/org/lflang/generator/GeneratorBase.xtend
@@ -229,18 +229,6 @@ abstract class GeneratorBase extends AbstractLFValidator {
     protected String classpathLF
 
     /**
-     * The index available to user-generated reaction that delineates the index
-     * of the reactor in a bank of reactors. The value must be set to zero
-     * in generated code for reactors that are not in a bank
-     */
-    protected String targetBankIndex = "bank_index"
-
-    /**
-     * The type of the bank index, which must be an integer in the target language
-     */
-    protected String targetBankIndexType = "int"
-
-    /**
      * The name of the top-level reactor.
      */
     protected var String topLevelName; // FIXME: remove and use fileConfig.name instead

--- a/org.lflang/src/org/lflang/generator/ParameterInstance.xtend
+++ b/org.lflang/src/org/lflang/generator/ParameterInstance.xtend
@@ -27,8 +27,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package org.lflang.generator
 
+import java.util.LinkedList
 import java.util.List
 import org.lflang.InferredType
+import org.lflang.lf.LfFactory
 import org.lflang.lf.Parameter
 import org.lflang.lf.Value
 
@@ -68,7 +70,24 @@ class ParameterInstance extends NamedInstance<Parameter> {
             // a list of ordinary values.
             val ref = assignment.rhs.get(0).parameter
             if (ref !== null) {
-                this.init = ref.init
+                // Get the value from the parameter instance, not the parameter
+                // so that overrides like bank_index work.
+                // parent.parent will be non-null or the rhs parameter reference
+                // would not have passed validation. Nevertheless, we check.
+                val parentsParent = parent.parent;
+                if (parentsParent !== null) {
+                    val parameterInstance = parentsParent.parameters.findFirst[it.name.equals(ref.name)]
+                    // Again, this result should be non-null, but we check.
+                    if (parameterInstance !== null) {
+                        this.init = parameterInstance.init
+                    } else {
+                        // Fall back on reference.
+                        this.init = ref.init
+                    }
+                } else {
+                    // Fall back on reference.
+                    this.init = ref.init
+                }
             } else {
                 this.init = assignment.rhs    
             }
@@ -77,6 +96,16 @@ class ParameterInstance extends NamedInstance<Parameter> {
             } else {
                 assignment = null
             }
+        }
+        
+        // If the parent is in a bank and the reactor name is "bank_index", then
+        // override the default value provided to make it equal to the bank index.
+        if (parent.bankIndex >= 0 && definition.name.equals("bank_index")) {
+            val value = LfFactory.eINSTANCE.createValue
+            value.literal = "" + parent.bankIndex
+            val list = new LinkedList<Value>()
+            list.add(value)
+            this.init = list
         }
     }
 

--- a/org.lflang/src/org/lflang/generator/ParameterInstance.xtend
+++ b/org.lflang/src/org/lflang/generator/ParameterInstance.xtend
@@ -98,7 +98,7 @@ class ParameterInstance extends NamedInstance<Parameter> {
             }
         }
         
-        // If the parent is in a bank and the reactor name is "bank_index", then
+        // If the parent is in a bank and the parameter name is "bank_index", then
         // override the default value provided to make it equal to the bank index.
         if (parent.bankIndex >= 0 && definition.name.equals("bank_index")) {
             val value = LfFactory.eINSTANCE.createValue

--- a/org.lflang/src/org/lflang/generator/PythonGenerator.xtend
+++ b/org.lflang/src/org/lflang/generator/PythonGenerator.xtend
@@ -1565,12 +1565,6 @@ class PythonGenerator extends CGenerator {
      */
     override generateParametersForReactor(StringBuilder builder, Reactor reactor) {
         for (parameter : reactor.allParameters) {
-            // Check for targetBankIndex
-            // FIXME: for now throw a reserved error
-            if (parameter.name.equals(targetBankIndex)) {
-                errorReporter.reportError('''«targetBankIndex» is reserved.''')
-            }
-
             prSourceLineNumber(builder, parameter)
             // Assume all parameters are integers
             pr(builder,'''int «parameter.name» ;''');

--- a/org.lflang/src/org/lflang/generator/ReactorInstance.xtend
+++ b/org.lflang/src/org/lflang/generator/ReactorInstance.xtend
@@ -852,7 +852,7 @@ class ReactorInstance extends NamedInstance<Instantiation> {
     }
     
     /**
-     * Returns the size of this bank.
+     * Return the size of this bank.
      * @return actual bank size or -1 if this is not a bank master.
      */
     def int getBankSize() {
@@ -863,7 +863,7 @@ class ReactorInstance extends NamedInstance<Instantiation> {
     }
     
     /**
-     * Returns the index of this reactor within a bank, or -1 if it
+     * Return the index of this reactor within a bank, or -1 if it
      * it is not within a bank, or -2 if it is itself the placeholder
      * for a bank.
      */
@@ -872,11 +872,25 @@ class ReactorInstance extends NamedInstance<Instantiation> {
     }
     
     /**
-     * Returns the members of this bank, or null if there are none.
+     * Return the members of this bank, or null if there are none.
      * @return actual bank size or -1 if this is not a bank master.
      */
     def getBankMembers() {
         bankMembers
+    }
+    
+    /**
+     * Return a parameter matching the specified name if the reactor has one
+     * and otherwise return null.
+     * @param name The parameter name.
+     */
+    def ParameterInstance getParameter(String name) {
+        for (parameter: parameters) {
+            if (parameter.name.equals(name)) {
+                return parameter;
+            }
+        }
+        return null;
     }
 
     //////////////////////////////////////////////////////
@@ -1033,13 +1047,13 @@ class ReactorInstance extends NamedInstance<Instantiation> {
      * Create reactor instance resulting from the specified top-level instantiation.
      * @param instance The Instance statement in the AST.
      * @param parent The parent, or null for the main rector.
-     * @param generator The generator (for error reporting).
+     * @param reporter The error reporter.
      * @param desiredDepth The depth to which to expand the hierarchy.
      */
-    private new(Instantiation definition, ReactorInstance parent, ErrorReporter generator, int desiredDepth) {
+    private new(Instantiation definition, ReactorInstance parent, ErrorReporter reporter, int desiredDepth) {
         // If the reactor is being instantiated with new[width], then pass -2
         // to the constructor, otherwise pass -1.
-        this(definition, parent, generator, (definition.widthSpec !== null)? -2 : -1, 0, desiredDepth)
+        this(definition, parent, reporter, (definition.widthSpec !== null)? -2 : -1, 0, desiredDepth)
     }
 
     /**

--- a/test/C/src/concurrent/Tracing.lf
+++ b/test/C/src/concurrent/Tracing.lf
@@ -14,7 +14,9 @@ reactor Source {
 		self->s++;
 	=}
 }
-reactor TakeTime {
+reactor TakeTime(
+    bank_index:int(0)
+) {
 	input in:int;
 	output out:int;
 	state event:string("No ID");

--- a/test/C/src/multiport/BankSelfBroadcast.lf
+++ b/test/C/src/multiport/BankSelfBroadcast.lf
@@ -7,7 +7,9 @@
  * @author Edward A. Lee 
  */
 target C;
-reactor A {
+reactor A (
+    bank_index:int(0)
+) {
     input[4] in:int;
     output out:int;
     state received:bool(false);

--- a/test/C/src/multiport/BankToBank.lf
+++ b/test/C/src/multiport/BankToBank.lf
@@ -4,7 +4,9 @@ target C {
     fast: true,
     threads: 4
 };
-reactor Source {
+reactor Source(
+    bank_index:int(0)
+) {
 	timer t(0, 200 msec);
 	output out:int;
 	state s:int(0);
@@ -13,7 +15,9 @@ reactor Source {
    	    self->s += self->bank_index;
 	=}
 }
-reactor Destination {
+reactor Destination(
+    bank_index:int(0)
+) {
 	state s:int(0);
 	input in:int;
 	reaction(in) {=

--- a/test/C/src/multiport/BankToMultiport.lf
+++ b/test/C/src/multiport/BankToMultiport.lf
@@ -1,7 +1,9 @@
 // Test bank of reactors to multiport input with id parameter in the bank.
 target C;
 
-reactor Source {
+reactor Source(
+    bank_index:int(0)
+) {
     output out:int;
     
     reaction (startup) -> out {=

--- a/test/C/src/multiport/MultiportFromBank.lf
+++ b/test/C/src/multiport/MultiportFromBank.lf
@@ -5,7 +5,10 @@ target C {
     threads: 4,
     fast: true
 }; 
-reactor Source(check_override:int(0)) {
+reactor Source(
+    check_override:int(0),
+    bank_index:int(0)
+) {
     output out:int;
     reaction(startup) -> out {=
         SET(out, self->bank_index * self->check_override);

--- a/test/C/src/multiport/MultiportToBank.lf
+++ b/test/C/src/multiport/MultiportToBank.lf
@@ -19,7 +19,9 @@ reactor Source(width:int(2)) {
         }
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index:int(0)
+) {
     input in:int;
     state received:bool(false);
     reaction(in) {=

--- a/test/C/src/multiport/MultiportToBankAfter.lf
+++ b/test/C/src/multiport/MultiportToBankAfter.lf
@@ -11,7 +11,9 @@ reactor Source(width:int(2)) {
         }
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index:int(0)
+) {
     input in:int;
     state received:bool(false);
     reaction(in) {=

--- a/test/C/src/multiport/MultiportToBankDouble.lf
+++ b/test/C/src/multiport/MultiportToBankDouble.lf
@@ -19,7 +19,9 @@ reactor Source {
         }
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index:int(0)
+) {
     input in:int;
     state received:bool(false);
     reaction(in) {=

--- a/test/C/src/multiport/MultiportToBankHierarchy.lf
+++ b/test/C/src/multiport/MultiportToBankHierarchy.lf
@@ -13,7 +13,9 @@ reactor Source(width:int(2)) {
         }
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index:int(0)
+) {
     input in:int;
     state received:bool(false);
     reaction(in) {=

--- a/test/Python/src/multiport/BankToBank.lf
+++ b/test/Python/src/multiport/BankToBank.lf
@@ -3,7 +3,9 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source {
+reactor Source(
+    bank_index(0)
+) {
 	timer t(0, 200 msec);
 	output out;
 	state s(0);
@@ -12,7 +14,9 @@ reactor Source {
         self.s += self.bank_index
 	=}
 }
-reactor Destination {
+reactor Destination(
+    bank_index(0)
+) {
 	state s(0);
 	input _in;
 	reaction(_in) {=

--- a/test/Python/src/multiport/BankToMultiport.lf
+++ b/test/Python/src/multiport/BankToMultiport.lf
@@ -1,7 +1,9 @@
 // Test bank of reactors to multiport input with id parameter in the bank.
 target Python;
 
-reactor Source {
+reactor Source(
+    bank_index(0)
+) {
     output out;
     
     reaction (startup) -> out {=

--- a/test/Python/src/multiport/MultiportFromBank.lf
+++ b/test/Python/src/multiport/MultiportFromBank.lf
@@ -4,7 +4,10 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source(check_override(0)) {
+reactor Source(
+    check_override(0),
+    bank_index(0)
+) {
     output out;
     reaction(startup) -> out {=
         out.set(self.bank_index * self.check_override)

--- a/test/Python/src/multiport/MultiportFromBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchy.lf
@@ -4,7 +4,9 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source {
+reactor Source(
+    bank_index(0)
+) {
     output out;
     reaction(startup) -> out {=
         out.set(self.bank_index)

--- a/test/Python/src/multiport/MultiportFromBankHierarchyAfter.lf
+++ b/test/Python/src/multiport/MultiportFromBankHierarchyAfter.lf
@@ -4,7 +4,9 @@ target Python {
     timeout: 2 sec,
     fast: true
 }; 
-reactor Source {
+reactor Source(
+    bank_index(0)
+) {
     output out;
     reaction(startup) -> out {=
         out.set(self.bank_index)

--- a/test/Python/src/multiport/MultiportToBank.lf
+++ b/test/Python/src/multiport/MultiportToBank.lf
@@ -10,7 +10,9 @@ reactor Source {
             out[i].set(i)
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index(0)
+) {
     input _in;
     state received(0);
     reaction(_in) {=

--- a/test/Python/src/multiport/MultiportToBankAfter.lf
+++ b/test/Python/src/multiport/MultiportToBankAfter.lf
@@ -10,7 +10,9 @@ reactor Source {
             out[i].set(i);
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index(0)
+) {
     input _in;
     state received(false);
     reaction(_in) {=

--- a/test/Python/src/multiport/MultiportToBankHierarchy.lf
+++ b/test/Python/src/multiport/MultiportToBankHierarchy.lf
@@ -11,7 +11,9 @@ reactor Source {
             out[i].set(i)
     =}
 }
-reactor Destination {
+reactor Destination(
+    bank_index(0)
+) {
     input _in;
     state received(false);
     reaction(_in) {=


### PR DESCRIPTION
This PR makes bank_index a parameter in the C and Python targets. If you define a parameter named `bank_index` in a reactor and then instantiate that reactor in a bank, the parameter will be automatically set to the bank index. This allows passing the parameter to contained reactors, something that was not possible before.

I believe this also brings the C and Python target into a consistent state with the Cpp target. However, I'm not sure. The bank_index parameter usage does not seem to be documented for Cpp, so I'm not sure how it work.

When we merge this PR with master, which I hope will be soon, we will need to update the [multiports and banks](https://github.com/icyphy/lingua-franca/wiki/Multiports-and-Banks-of-Reactors) documentation.