### PR TITLE
Assume width 1 if width cannot be determined for multiports.

### DIFF
--- a/org.lflang/src/org/lflang/generator/MultiportInstance.xtend
+++ b/org.lflang/src/org/lflang/generator/MultiportInstance.xtend
@@ -67,10 +67,10 @@ class MultiportInstance extends PortInstance {
                     // This could throw NumberFormatException
                     width += parameterValue
                 } else {
-                    reporter.reportError(definition,
-                        "Width of a multiport must be given as an integer. It is: "
-                        + parameterValue
+                    reporter.reportWarning(definition,
+                        "Width of a multiport cannot be determined. Assuming 1."
                     )
+                    width += 1
                 }
             } else {
                 width += term.width


### PR DESCRIPTION
If the width of a multiport cannot be determined, issue a warning and assume 1. This is for diagram synthesis.