### PR TITLE
Fix sudo permissions

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - name: Install jq # for pruning old release assets
         run: |
-          apt update
-          apt -y install jq
+          sudo apt update
+          sudo apt -y install jq
       # Setup Build dependencies
       - name: Setup Java JDK
         uses: actions/setup-java@v2


### PR DESCRIPTION
Add `sudo` to the nightly workflow. That was not required in the local build (probably a quirk of the `act` tool) but is necessary here.

Also sorry for the PR for something small like this, but `master` is protected. Which is good practice but always annoying when doing tinkering with CI. 😅