### PR TITLE
Klighd Version Update

### DIFF
--- a/oomph/LinguaFranca.setup
+++ b/oomph/LinguaFranca.setup
@@ -369,7 +369,7 @@
           <repository
               url="http://download.eclipse.org/elk/updates/releases/0.7.1/"/>
           <repository
-              url="https://kieler.github.io/KLighD/v2.0.0/"/>
+              url="https://kieler.github.io/KLighD/v2.1.0/"/>
           <repository
               url="https://www.pydev.org/updates/"/>
           <repository

--- a/org.lflang.targetplatform/org.lflang.targetplatform.target
+++ b/org.lflang.targetplatform/org.lflang.targetplatform.target
@@ -52,7 +52,7 @@
       <unit id="de.cau.cs.kieler.klighd.view.feature.feature.group" version="0.0.0"/>
       <unit id="de.cau.cs.kieler.klighd.freehep.feature.feature.group" version="0.0.0"/>
       <unit id="de.cau.cs.kieler.klighd.ui.contrib3x" version="0.0.0"/>
-      <repository location="https://kieler.github.io/KLighD/v2.0.0/"/>
+      <repository location="https://kieler.github.io/KLighD/v2.1.0/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.graphviz.feature.feature.group" version="0.0.0"/>


### PR DESCRIPTION
Updates Klighd version in oomph and maven target platform.

The new release finally fixes the disappearing refresh button in the diagram toolbar and makes some internal improvements in the LS for the new [Klighd VSC extension](https://github.com/kieler/klighd-vscode).