### PR TITLE
Cpp: Support generic parameters

### DIFF
--- a/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/cpp/CppParameterGenerator.kt
@@ -56,13 +56,13 @@ class CppParameterGenerator(private val reactor: Reactor) {
         /** Get a C++ type that is a const reference to the parameter type */
         val Parameter.constRefType: String
             get() =
-                "std::add_lvalue_reference<std::add_const<$targetType>::type>::type"
+                "typename std::add_lvalue_reference<typename std::add_const<$targetType>::type>::type"
     }
 
     /** Generate all parameter declarations */
     fun generateDeclarations() =
         reactor.parameters.joinToString("\n", "// parameters\n", "\n") {
-            "std::add_const<${it.targetType}>::type ${it.name};"
+            "typename std::add_const<${it.targetType}>::type ${it.name};"
         }
 
     /** Generate all constructor initializers for parameters */

--- a/test/Cpp/src/target/GenericParameterAndState.lf
+++ b/test/Cpp/src/target/GenericParameterAndState.lf
@@ -1,0 +1,20 @@
+target Cpp;
+
+reactor Foo<T> (bar:T(0)) {
+  state baz:T(bar)
+
+  reaction (startup) {=
+    if (bar != 42) {
+      std::cerr << "ERROR: Expected baz=42 but got baz=" << bar << '\n';
+      exit(1);
+    }
+    if (baz != 42) {
+      std::cerr << "ERROR: Expected baz=42 but got baz=" << baz << '\n';
+      exit(1);
+    }
+  =}
+}
+
+main reactor {
+  foo = new Foo<int>(bar=42)
+}


### PR DESCRIPTION
Type parameters could be used as types for reactor reactor parameters as is shown in the following example:
```
reactor<T> (bar:T(0)) {
}
```
However, this is currently not properly supported by the C++ generator and it produces invalid code. This PR slightly modifies the generator, so that it produces correct code for generic parameters. This PR also adds a new test case.