### PR TITLE
file-config: place binaries in bin, not src-gen/bin

### DIFF
--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -175,7 +175,7 @@ public class FileConfig {
         this.srcGenPath = getSrcGenPath(this.srcGenBasePath, this.srcPkgPath,
                 this.srcPath, name);
         this.srcGenPkgPath = this.srcGenPath;
-        this.outPath = getOutputRoot(srcGenBasePath);
+        this.outPath = srcGenBasePath.resolve("..");
         this.binPath = getBinPath(this.srcPkgPath, this.srcPath, this.outPath, context);
         this.iResource = getIResource(resource);
     }
@@ -201,7 +201,7 @@ public class FileConfig {
         this.srcGenPath = getSrcGenPath(this.srcGenBasePath, this.srcPkgPath,
                 this.srcPath, name);
         this.srcGenPkgPath = this.srcGenPath;
-        this.outPath = getOutputRoot(srcGenBasePath);
+        this.outPath = srcGenBasePath.resolve("..");
         this.binPath = getBinPath(this.srcPkgPath, this.srcPath, this.outPath, context);
         this.iResource = getIResource(resource);
     }
@@ -350,10 +350,6 @@ public class FileConfig {
      */
     public Path getRTIBinPath() {
         return this.binPath;
-    }
-
-    private static Path getOutputRoot(Path srcGenRoot) {
-        return Paths.get(".").resolve(srcGenRoot);
     }
 
     /**


### PR DESCRIPTION
It seems that #435 introduced a bug that caused all binaries to be located in `src-gen/bin`, while they are expected to be placed in `bin`. It seems a bit surprising that no one noticed this subtle change. I am not sure why exactly the behavior changes, as @oowekyala's commits in #435 look good in a first glance. I suspect that `resolve()` works different for URIs and Paths, which could have caused this bug. In any case, this PR should fix the problem and revert to the old behavior.