### PR TITLE
FileConfig: make resolution of project root more robust

### DIFF
--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -201,7 +201,7 @@ public class FileConfig {
         this.srcGenPath = getSrcGenPath(this.srcGenBasePath, this.srcPkgPath,
                 this.srcPath, name);
         this.srcGenPkgPath = this.srcGenPath;
-        this.outPath = srcGenBasePath.resolve("..");
+        this.outPath = srcGenBasePath.getParent();
         this.binPath = getBinPath(this.srcPkgPath, this.srcPath, this.outPath, context);
         this.iResource = getIResource(resource);
     }

--- a/org.lflang/src/org/lflang/FileConfig.java
+++ b/org.lflang/src/org/lflang/FileConfig.java
@@ -175,7 +175,7 @@ public class FileConfig {
         this.srcGenPath = getSrcGenPath(this.srcGenBasePath, this.srcPkgPath,
                 this.srcPath, name);
         this.srcGenPkgPath = this.srcGenPath;
-        this.outPath = srcGenBasePath.resolve("..");
+        this.outPath = srcGenBasePath.getParent();
         this.binPath = getBinPath(this.srcPkgPath, this.srcPath, this.outPath, context);
         this.iResource = getIResource(resource);
     }


### PR DESCRIPTION
This makes the resolution of the project root more robust. Before, the resulting
path would include the '..'. Also, for some reason that I don't quite
understand, this broke the check for existence of a directory and, in consequence,
lfc -c did not work as expected. This is fixed now.