### PR TITLE
Tuning sensor simulator

### DIFF
--- a/example/C/src/Rhythm/SensorSimulator.lf
+++ b/example/C/src/Rhythm/SensorSimulator.lf
@@ -5,24 +5,27 @@
 target C {
     threads: 2,
     flags: "-lncurses",
+    cmake: false,
     files: ["/lib/C/util/sensor_simulator.c", "/lib/C/util/sensor_simulator.h"]
 };
 preamble {=
     #include "sensor_simulator.c"
+    char* messages[] = {"Hello", "World"};
+    int num_messages = 2;
 =}
 main reactor {
     timer t(0, 1 sec);
     timer r(0, 2 sec);
     reaction(startup) {=
-    	char* messages[] = {"Hello", "World"};
     	info_print("Starting sensor simulator.");
-        start_sensor_simulator(messages, 2, 16, NULL, -1);
+        start_sensor_simulator(messages, num_messages, 16, NULL, LOG_LEVEL_INFO);
     	info_print("Started sensor simulator.");
    =}
     reaction(t) {=
         show_tick("*");
     =}
     reaction(r) {=
+        info_print("Elapsed logical time: %lld.", get_elapsed_logical_time());
         show_tick(".");
     =}
 }

--- a/example/C/src/Rhythm/SensorSimulator.lf
+++ b/example/C/src/Rhythm/SensorSimulator.lf
@@ -4,8 +4,7 @@
  */
 target C {
     threads: 2,
-    flags: "-lncurses",
-    cmake: false,
+    cmake-include: "include/ncurses-cmake-extension.txt", // Adds support for ncurses
     files: ["/lib/C/util/sensor_simulator.c", "/lib/C/util/sensor_simulator.h"]
 };
 preamble {=

--- a/example/C/src/Rhythm/SensorSimulator.lf
+++ b/example/C/src/Rhythm/SensorSimulator.lf
@@ -15,10 +15,11 @@ preamble {=
 main reactor {
     timer t(0, 1 sec);
     timer r(0, 2 sec);
-    reaction(startup) {=
+    physical action key:char*;
+    reaction(startup) -> key {=
     	info_print("Starting sensor simulator.");
         start_sensor_simulator(messages, num_messages, 16, NULL, LOG_LEVEL_INFO);
-    	info_print("Started sensor simulator.");
+    	register_sensor_key('\0', key);
    =}
     reaction(t) {=
         show_tick("*");
@@ -26,5 +27,8 @@ main reactor {
     reaction(r) {=
         info_print("Elapsed logical time: %lld.", get_elapsed_logical_time());
         show_tick(".");
+    =}
+    reaction(key) {=
+        info_print("You typed '%s' at elapsed time %lld.", key->value, get_elapsed_logical_time());
     =}
 }

--- a/example/C/src/Rhythm/include/ncurses-cmake-extension.txt
+++ b/example/C/src/Rhythm/include/ncurses-cmake-extension.txt
@@ -1,0 +1,3 @@
+find_package(Curses REQUIRED) # Finds the lncurses library
+include_directories(${CURSES_INCLUDE_DIR}) # "The include directories needed to use Curses"
+target_link_libraries( ${LF_MAIN_TARGET} ${CURSES_LIBRARIES} ) # Links the Curses library

--- a/org.lflang/src/lib/C/util/sensor_simulator.c
+++ b/org.lflang/src/lib/C/util/sensor_simulator.c
@@ -183,9 +183,10 @@ void _lf_start_print_window(int above, int right) {
 
 /**
  * Post a message to be displayed.
+ * This acquires the mutex lock.
  * @param type The message type, one of
- *  _lf_sensor_message, _lf_sensor_tick, or _lf_sesor_close_window.
- * @param message The message, or NULL for exit type.
+ *  _lf_sensor_message, _lf_sensor_tick, or _lf_sensor_close_window.
+ * @param body The message, or NULL for exit type.
  */
 void _lf_sensor_post_message(enum _lf_sensor_message_type type, char* body) {
     lf_mutex_lock(&_lf_sensor_mutex);
@@ -199,18 +200,20 @@ void _lf_sensor_post_message(enum _lf_sensor_message_type type, char* body) {
     }
     message->message = body;
     message->type = type;
-	message->next = NULL;
-	// Find the tail of the message queue.
+	message->next = NULL; // Will be the new last message in the queue.
+	// Find the tail of the message queue and put the message there.
 	_lf_sensor_message_t* tail = _lf_sensor.message_q;
 	if (tail == NULL) {
 		_lf_sensor.message_q = message;
 	} else {
 		while (tail != NULL) {
-			_lf_sensor_message_t* next = tail->next;
-			if (next == NULL) {
+			if (tail->next == NULL) {
+				// tail is the last message in the queue.
 				tail->next = message;
+				break;
 			}
-			tail = next;
+			// Not yet at the last message.
+			tail = tail->next;
 		}
 	}
 	lf_cond_signal(&_lf_sensor_simulator_cond_var);
@@ -223,9 +226,8 @@ void _lf_sensor_post_message(enum _lf_sensor_message_type type, char* body) {
  */
 void _lf_print_message_function(char* format, va_list args) {
 	if (_lf_sensor.log_file != NULL) {
-		// Write to a log file instead of to the window.
+		// Write to a log file in addition to the window.
 		vfprintf(_lf_sensor.log_file, format, args);
-		return;
 	}
     char* copy;
     vasprintf(&copy, format, args);
@@ -308,10 +310,11 @@ void* _lf_sensor_simulator_thread(void* ignored) {
     }
 
     while(_lf_sensor.thread_created != 0) {
-    	// Sadly, ncurses is not thread safe, so there is no way to
+    	// Sadly, ncurses is not thread safe, so this thread deals with all messages.
     	while (_lf_sensor.message_q == NULL) {
             lf_cond_wait(&_lf_sensor_simulator_cond_var, &_lf_sensor_mutex);
     	}
+    	// Show all messages in the queue.
 		while (_lf_sensor.message_q != NULL) {
 			if (_lf_sensor.message_q->type == _lf_sensor_close_windows) {
 			    register_print_function(NULL, -1);
@@ -333,10 +336,6 @@ void* _lf_sensor_simulator_thread(void* ignored) {
 			    }
 			    wmove(_lf_sensor.tick_window, _lf_sensor.tick_cursor_y, _lf_sensor.tick_cursor_x);
 			    wrefresh(_lf_sensor.tick_window);
-
-			    // Move the standard string cursor to 0, 0, so printf()
-			    // calls don't mess up the screen as much.
-			    // wmove(stdscr, 0, 0);
 			} else if (_lf_sensor.message_q->type == _lf_sensor_message) {
 				wmove(_lf_sensor.print_window, _lf_sensor.print_cursor_y, _lf_sensor.print_cursor_x);
 				wclrtoeol(_lf_sensor.print_window);
@@ -356,8 +355,8 @@ void* _lf_sensor_simulator_thread(void* ignored) {
 			_lf_sensor_message_t* tmp_recycle = _lf_sensor.message_recycle_q;
 			_lf_sensor_message_t* tmp_message = _lf_sensor.message_q;
 			_lf_sensor.message_recycle_q = _lf_sensor.message_q;
-			_lf_sensor.message_recycle_q->next = tmp_recycle;
 			_lf_sensor.message_q = tmp_message->next;
+			_lf_sensor.message_recycle_q->next = tmp_recycle;
 		}
     }
     lf_mutex_unlock(&_lf_sensor_mutex);
@@ -389,7 +388,10 @@ void end_sensor_simulator() {
  * call to register_sensor_key.  The specified message
  * is an initial message to display at the upper left,
  * typically a set of instructions, that remains displayed
- * throughout the lifetime of the window.
+ * throughout the lifetime of the window. Please ensure that
+ * the message_lines array and its contained strings are not
+ * on the stack because they will be used later in a separate
+ * thread.
  * @param message_lines The message lines.
  * @param number_of_lines The number of lines.
  * @param tick_window_width The width of the tick window or 0 for none.

--- a/org.lflang/src/lib/C/util/sensor_simulator.c
+++ b/org.lflang/src/lib/C/util/sensor_simulator.c
@@ -439,7 +439,7 @@ int start_sensor_simulator(
 
         // ncurses is not thread safe, so create a one thread that does all
         // the writing to the window and one that does all the reading.
-        int result = lf_thread_create(&_lf_sensor.output_thread_id, &_lf_sensor_simulator_thread, NULL);
+        result = lf_thread_create(&_lf_sensor.output_thread_id, &_lf_sensor_simulator_thread, NULL);
         if (result != 0) {
             error_print("Failed to start sensor simulator!");
         }

--- a/org.lflang/src/lib/C/util/sensor_simulator.c
+++ b/org.lflang/src/lib/C/util/sensor_simulator.c
@@ -288,6 +288,7 @@ void* _lf_sensor_simulator_thread(void* ignored) {
     noecho();          // Don't echo input
     cbreak();          // Don't wait for Return or Enter
     wtimeout(stdscr, WGETCHR_TIMEOUT); // Don't wait longer than this for input.
+    keypad(stdscr, TRUE);  // Enable keypad input.
     refresh();         // Not documented, but needed?
 
     _lf_sensor.default_window = stdscr;

--- a/org.lflang/src/lib/C/util/sensor_simulator.h
+++ b/org.lflang/src/lib/C/util/sensor_simulator.h
@@ -35,6 +35,7 @@ To use this, include the following flags in your target properties:
 <pre>
 target C {
     flags: "-lncurses",
+    cmake: false,
     files: ["/lib/C/util/sensor_simulator.c", "/lib/C/util/sensor_simulator.h"]
 };
 </pre>

--- a/org.lflang/src/lib/C/util/sensor_simulator.h
+++ b/org.lflang/src/lib/C/util/sensor_simulator.h
@@ -34,8 +34,7 @@ provides a convenient way to do that.
 To use this, include the following flags in your target properties:
 <pre>
 target C {
-    flags: "-lncurses",
-    cmake: false,
+    cmake-include: "include/ncurses-cmake-extension.txt", // Adds support for ncurses
     files: ["/lib/C/util/sensor_simulator.c", "/lib/C/util/sensor_simulator.h"]
 };
 </pre>

--- a/org.lflang/src/lib/core/util.c
+++ b/org.lflang/src/lib/core/util.c
@@ -97,7 +97,7 @@ void _lf_message_print(
         } else {
             vfprintf(stdout, message, args);
         }
-    } else if (log_level < print_message_level) {
+    } else if (log_level <= print_message_level) {
         (*print_message_function)(message, args);
     }
 }


### PR DESCRIPTION
This fixes a segfault in the SensorSimulator example and fixes a bug where, if multiple messages were sent to be displayed simultaneously, all but the first message would be lost.