### PR TITLE
Fix error message display when line has tabs

### DIFF
--- a/org.lflang/src/org/lflang/generator/ReportingUtil.kt
+++ b/org.lflang/src/org/lflang/generator/ReportingUtil.kt
@@ -294,14 +294,23 @@ class ReportingBackend constructor(
 
 
         private fun makeErrorLine(pad: Int): String {
-            val caretLine = with(issue) { buildCaretLine(message.trim(), column!!, length!!) }
+            // tabs are replaced with spaces to align messages properly
+            fun makeOffset(startIdx: Int, length: Int): Int {
+                val numTabs = lines[errorIdx].substring(startIdx, startIdx + length).count { it == '\t' }
+                return numTabs * (TAB_REPLACEMENT.length - 1)
+            }
+
+            val tabOffset = makeOffset(0, issue.column!!)
+            val tabSpanOffset = makeOffset(issue.column - 1, issue.length!!)
+
+            val caretLine = with(issue) { buildCaretLine(message.trim(), column!! + tabOffset, length!! + tabSpanOffset) }
             // gutter has its own ANSI stuff so only caretLine gets severityColors
             return emptyGutter(pad) + colors.severityColors(caretLine, issue.severity)
         }
 
         private fun numberedLine(idx: Int, pad: Int): String {
             val lineNum = 1 + idx + first
-            val line = lines[idx]
+            val line = lines[idx].replace("\t", TAB_REPLACEMENT)
             return formatLineNum("$lineNum |".padStart(pad)) + " $line"
         }
 
@@ -320,6 +329,10 @@ class ReportingBackend constructor(
                 append(' ').append(message)
             }
         }
+    }
+
+    companion object {
+        const val TAB_REPLACEMENT = "    "
     }
 }
 


### PR DESCRIPTION
The new error messages are off when the error line has tabs:

![Capture d’écran de 2021-08-31 17-22-23](https://user-images.githubusercontent.com/24524930/131530495-943b8501-6cd8-448a-9380-55ba065667f2.png)

This is now fixed:
![Capture d’écran de 2021-08-31 17-25-33](https://user-images.githubusercontent.com/24524930/131530931-29a228c3-b0c2-4282-913b-2d7fc8039b55.png)

