### PR TITLE
Update benchmark runner to support hydra 1.1 and distinguish threaded and unthreaded C runtime.

### DIFF
--- a/benchmark/C/Savina/src/micro/Counting.lf
+++ b/benchmark/C/Savina/src/micro/Counting.lf
@@ -38,7 +38,16 @@
  ]]] */
  // [[[end]]]
 
-target C;
+target C {
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads},")
+      else:
+          cog.outl("threads: 0,")
+    ]]] */
+    threads: 0,
+    /// [[[end]]]
+}
 
 reactor ProducerReactor(countTo:int(1000000)) {
 

--- a/benchmark/C/Savina/src/micro/PingPong.lf
+++ b/benchmark/C/Savina/src/micro/PingPong.lf
@@ -23,9 +23,17 @@
  * @author Edward A. Lee
  */
 target C {
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads},")
+      else:
+          cog.outl("threads: 0,")
+    ]]] */
+    threads: 0,
+    /// [[[end]]]
     fast: true
 };
-reactor Ping(count:int(1000000)) {
+reactor Ping(count:int(10000000)) {
     input receive:int;
     output send:int;
     state pingsLeft:int(count);
@@ -41,7 +49,7 @@ reactor Ping(count:int(1000000)) {
         }
     =}
 }
-reactor Pong(expected:int(1000000)) {
+reactor Pong(expected:int(10000000)) {
     input receive:int;
     output send:int;
     state count:int(0);

--- a/benchmark/C/Savina/src/micro/ThreadRing.lf
+++ b/benchmark/C/Savina/src/micro/ThreadRing.lf
@@ -48,6 +48,14 @@
 // [[[end]]]
 
 target C {
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads},")
+      else:
+          cog.outl("threads: 0,")
+    ]]] */
+    threads: 0,
+    /// [[[end]]]
     tracing: true
 };
 

--- a/benchmark/C/Savina/src/micro/Throughput.lf
+++ b/benchmark/C/Savina/src/micro/Throughput.lf
@@ -53,8 +53,16 @@
 // [[[end]]]
 
 target C {
+    /* [[[cog
+      if (threaded_runtime=="True"):
+          cog.outl(f"threads: {threads},")
+      else:
+          cog.outl("threads: 0,")
+    ]]] */
+    threads: 0,
+    /// [[[end]]]
     flags: "-lm",
-    fast: true
+    fast: true,
 };
 
 

--- a/benchmark/runner/conf/default.yaml
+++ b/benchmark/runner/conf/default.yaml
@@ -1,8 +1,9 @@
 iterations: 12
 threads: null
-savina_path: "${env:SAVINA_PATH}"
-lf_path: "${env:LF_PATH}"
+savina_path: "${oc.env:SAVINA_PATH}"
+lf_path: "${oc.env:LF_PATH}"
 continue_on_error: False
 defaults:
   - benchmark: ???
   - target: ???
+  - _self_

--- a/benchmark/runner/conf/target/akka.yaml
+++ b/benchmark/runner/conf/target/akka.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: akka
 prepare: null
 copy: null

--- a/benchmark/runner/conf/target/caf.yaml
+++ b/benchmark/runner/conf/target/caf.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: caf
 prepare: null
 copy: null

--- a/benchmark/runner/conf/target/lf-c-unthreaded.yaml
+++ b/benchmark/runner/conf/target/lf-c-unthreaded.yaml
@@ -1,4 +1,5 @@
-name: lf-c-unthreaded
+name: "lf-c unthreaded"
+validation_alias: "lf-c"
 prepare: ["mkdir", "src"]
 copy: ["cp", "-r", "${benchmark.targets.lf-c.copy_sources}", "src"]
 gen: ["cog", "-r", "${args:benchmark.targets.lf-c.gen_args}",

--- a/benchmark/runner/conf/target/lf-c-unthreaded.yaml
+++ b/benchmark/runner/conf/target/lf-c-unthreaded.yaml
@@ -3,7 +3,7 @@ prepare: ["mkdir", "src"]
 copy: ["cp", "-r", "${benchmark.targets.lf-c.copy_sources}", "src"]
 gen: ["cog", "-r", "${args:benchmark.targets.lf-c.gen_args}",
       "-D", "threads=${threads}",
-      "-D", "threaded_runtime=True",
+      "-D", "threaded_runtime=False",
       "src/${benchmark.targets.lf-c.lf_file}"]
 compile: ["${lf_path}/bin/lfc", "src/${benchmark.targets.lf-c.lf_file}"]
 run: ["bash", "-c", "seq ${iterations} | xargs -I{} bin/${benchmark.targets.lf-c.binary}"]

--- a/benchmark/runner/conf/target/lf-c-unthreaded.yaml
+++ b/benchmark/runner/conf/target/lf-c-unthreaded.yaml
@@ -1,4 +1,4 @@
-name: lf-c
+name: lf-c-unthreaded
 prepare: ["mkdir", "src"]
 copy: ["cp", "-r", "${benchmark.targets.lf-c.copy_sources}", "src"]
 gen: ["cog", "-r", "${args:benchmark.targets.lf-c.gen_args}",

--- a/benchmark/runner/conf/target/lf-c.yaml
+++ b/benchmark/runner/conf/target/lf-c.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: lf-c
 prepare: ["mkdir", "src"]
 copy: ["cp", "-r", "${benchmark.targets.lf-c.copy_sources}", "src"]

--- a/benchmark/runner/conf/target/lf-cpp.yaml
+++ b/benchmark/runner/conf/target/lf-cpp.yaml
@@ -1,4 +1,3 @@
-# @package _group_
 name: lf-cpp
 prepare: ["mkdir", "src"]
 copy: ["cp", "-r", "${benchmark.targets.lf-cpp.copy_sources}", "src"]

--- a/benchmark/runner/run_benchmark.py
+++ b/benchmark/runner/run_benchmark.py
@@ -50,7 +50,11 @@ def main(cfg):
     log.info(f"Running {benchmark_name} using the {target_name} target.")
 
     # perform some sanity checks
-    if not check_benchmark_target_config(benchmark, target_name):
+    if "validation_alias" in target:
+        target_validation_name = target["validation_alias"]
+    else:
+        target_validation_name = target_name
+    if not check_benchmark_target_config(benchmark, target_validation_name):
         if continue_on_error:
             return
         else:

--- a/benchmark/runner/run_benchmark.py
+++ b/benchmark/runner/run_benchmark.py
@@ -45,17 +45,7 @@ def main(cfg):
         return res
 
     # register the resolver for 'args:'
-
-    # HACK: When using multirun, we need to update the resolver for the new
-    # 'cfg.  However, OmegaConf throws an exception when the resolver was
-    # already registerd in another run.  Since OmegaConf does not seem to offer
-    # a way for deregistering a resolver we use this hack.
-    try:
-        omegaconf.basecontainer.BaseContainer._resolvers.pop("args")
-    except KeyError:
-        pass
-
-    omegaconf.OmegaConf.register_resolver("args", resolve_args)
+    omegaconf.OmegaConf.register_new_resolver("args", resolve_args, replace=True)
 
     log.info(f"Running {benchmark_name} using the {target_name} target.")
 


### PR DESCRIPTION
This PR does 2 things:
- Updating the hydra dependency. A new version of hydra (1.1) has been released. Hydra 1.1  brings a few important changes and also deprecates several functions. This PR adjusts both our configs and the runner script to the new requirements of hydra 1.1. This also means, that older hydra versions (<1.1) are not supported anymore.
- Adding a new target: the unthreaded C runtime. With this change, we can use `target=lf-c` for threaded C programs, and `target=lf-c-unthreaded` for unthreaded ones. Note, that this requires appropriate cog code in the individual C benchmarks to work correctly.

This PR is based on #406 and should only be merged after merging #406.