### PR TITLE
Migrate TypeScript code generation from pr(), indent(), unindent() style, using similar style as C++ code generators. Also modularize TypeScript code generators.

### DIFF
--- a/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
@@ -2,7 +2,6 @@ package org.lflang.generator.ts
 
 import org.lflang.generator.PrependOperator
 import org.lflang.lf.Action
-import org.lflang.lf.Reactor
 import org.lflang.lf.Type
 import org.lflang.lf.Value
 import java.util.*
@@ -10,7 +9,7 @@ import java.util.*
 class TSActionGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.
     private val tsGenerator: TSGenerator,
-    private val reactor: Reactor
+    private val actions: List<Action>
 ) {
     private fun Value.getTargetValue(): String = tsGenerator.getTargetValueW(this)
     private fun Type.getTargetType(): String = tsGenerator.getTargetTypeW(this)
@@ -32,7 +31,7 @@ class TSActionGenerator (
 
     fun generateClassProperties(): String {
         val stateClassProperties = LinkedList<String>()
-        for (action in reactor.actions) {
+        for (action in actions) {
             // Shutdown actions are handled internally by the
             // TypeScript reactor framework. There would be a
             // duplicate action if we included the one generated
@@ -50,7 +49,7 @@ class TSActionGenerator (
 
     fun generateInstantiations(): String {
         val actionInstantiations = LinkedList<String>()
-        for (action in reactor.actions) {
+        for (action in actions) {
             // Shutdown actions are handled internally by the
             // TypeScript reactor framework. There would be a
             // duplicate action if we included the one generated

--- a/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
@@ -1,11 +1,13 @@
 package org.lflang.generator.ts
 
-import org.lflang.generator.PrependOperator
 import org.lflang.lf.Action
 import org.lflang.lf.Type
 import org.lflang.lf.Value
 import java.util.*
 
+/**
+ * Generator for actions in TypeScript target.
+ */
 class TSActionGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.
     private val tsGenerator: TSGenerator,

--- a/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSActionGenerator.kt
@@ -40,11 +40,7 @@ class TSActionGenerator (
                 stateClassProperties.add("${action.name}: __Action<${getActionType(action)}>;")
             }
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..stateClassProperties.joinToString("\n")}
-            """.trimMargin()
-        }
+        return stateClassProperties.joinToString("\n")
     }
 
     fun generateInstantiations(): String {
@@ -69,10 +65,6 @@ class TSActionGenerator (
                     "this.${action.name} = new __Action<${getActionType(action)}>($actionArgs);")
             }
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..actionInstantiations.joinToString("\n")}
-            """.trimMargin()
-        }
+        return actionInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSConnectionGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSConnectionGenerator.kt
@@ -1,0 +1,45 @@
+package org.lflang.generator.ts
+
+import org.lflang.ErrorReporter
+import org.lflang.lf.Connection
+import java.util.*
+
+/**
+ * A code generator for connections using _connect() method of a TypeScript reactor class
+ * This class corresponds to CppAssembleMethodGenerator of C++ code generator.
+ */
+class TSConnectionGenerator (
+    private val connections: List<Connection>,
+    private val errorReporter: ErrorReporter
+) {
+    // There is no generateClassProperties() for connections
+
+    fun generateInstantiations(): String {
+        val connectionInstantiations = LinkedList<String>()
+        for (connection in connections) {
+            var leftPortName = ""
+            // FIXME: Add support for multiports.
+            if (connection.leftPorts.size > 1) {
+                errorReporter.reportError(connection, "Multiports are not yet supported in the TypeScript target.")
+            } else {
+                if (connection.leftPorts[0].container != null) {
+                    leftPortName += connection.leftPorts[0].container.name + "."
+                }
+                leftPortName += connection.leftPorts[0].variable.name
+            }
+            var rightPortName = ""
+            if (connection.leftPorts.size > 1) {
+                errorReporter.reportError(connection, "Multiports are not yet supported in the TypeScript target.")
+            } else {
+                if (connection.rightPorts[0].container != null) {
+                    rightPortName += connection.rightPorts[0].container.name + "."
+                }
+                rightPortName += connection.rightPorts[0].variable.name
+            }
+            if (leftPortName != "" && rightPortName != "") {
+                connectionInstantiations.add("this._connect(this.$leftPortName, this.$rightPortName);")
+            }
+        }
+        return connectionInstantiations.joinToString("\n")
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
@@ -8,6 +8,14 @@ import org.lflang.lf.Parameter
 import org.lflang.lf.Reactor
 import java.util.*
 
+/**
+ * Generator for code in the constructor of reactor class in TypeScript target.
+ * Specifically, this generator generates the code for constructor argument,
+ * call to the super class constructor. This generator uses other code generators
+ * for child reactors, timers, parameters, state variables, actions, ports, connections,
+ * and code to register reactions. This generator also generates federate port action
+ * registrations.
+ */
 class TSConstructorGenerator (
     private val tsGenerator: TSGenerator,
     private val errorReporter: ErrorReporter,
@@ -106,8 +114,8 @@ class TSConstructorGenerator (
         actions: TSActionGenerator,
         ports: TSPortGenerator
     ): String {
-        val connectionGenerator = TSConnectionGenerator(reactor.connections, errorReporter)
-        val reactionGenerator = TSReactionGenerator(tsGenerator, errorReporter, reactor, federate)
+        val connections = TSConnectionGenerator(reactor.connections, errorReporter)
+        val reactions = TSReactionGenerator(tsGenerator, errorReporter, reactor, federate)
 
         return with(PrependOperator) {
             """
@@ -121,9 +129,9 @@ class TSConstructorGenerator (
             ${" |    "..states.generateInstantiations()}
             ${" |    "..actions.generateInstantiations()}
             ${" |    "..ports.generateInstantiations()}
-            ${" |    "..connectionGenerator.generateInstantiations()}
+            ${" |    "..connections.generateInstantiations()}
             ${" |    "..if (reactor.isFederated) generateFederatePortActionRegistrations(federate.networkMessageActions) else ""}
-            ${" |    "..reactionGenerator.generateAllReactions()}
+            ${" |    "..reactions.generateAllReactions()}
                 |}
             """.trimMargin()
         }

--- a/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSConstructorGenerator.kt
@@ -1,0 +1,131 @@
+package org.lflang.generator.ts
+
+import org.lflang.ErrorReporter
+import org.lflang.generator.FederateInstance
+import org.lflang.generator.PrependOperator
+import org.lflang.lf.Action
+import org.lflang.lf.Parameter
+import org.lflang.lf.Reactor
+import java.util.*
+
+class TSConstructorGenerator (
+    private val tsGenerator: TSGenerator,
+    private val errorReporter: ErrorReporter,
+    private val reactor : Reactor,
+    private val federate: FederateInstance
+) {
+    private fun getInitializerList(param: Parameter): List<String> =
+        tsGenerator.getInitializerListW(param)
+
+    private fun Parameter.getTargetType(): String = tsGenerator.getTargetTypeW(this)
+
+    // Initializer functions
+    private fun getTargetInitializerHelper(param: Parameter,
+                                   list: List<String>): String {
+        return if (list.size == 0) {
+            errorReporter.reportError(param, "Parameters must have a default value!")
+        } else if (list.size == 1) {
+            list[0]
+        } else {
+            list.joinToString(", ", "[", "]")
+        }
+    }
+    private fun getTargetInitializer(param: Parameter): String {
+        return getTargetInitializerHelper(param, getInitializerList(param))
+    }
+    private fun initializeParameter(p: Parameter): String {
+        return """${p.name}: ${p.getTargetType()} = ${getTargetInitializer(p)}"""
+    }
+
+    private fun generateConstructorArguments(reactor: Reactor): String {
+        val arguments = LinkedList<String>()
+        if (reactor.isMain || reactor.isFederated) {
+            arguments.add("timeout: TimeValue | undefined = undefined")
+            arguments.add("keepAlive: boolean = false")
+            arguments.add("fast: boolean = false")
+        } else {
+            arguments.add("parent: __Reactor")
+        }
+
+        // For TS, parameters are arguments of the class constructor.
+        for (parameter in reactor.parameters) {
+            arguments.add(initializeParameter(parameter))
+        }
+
+        if (reactor.isMain || reactor.isFederated) {
+            arguments.add("success?: () => void")
+            arguments.add("fail?: () => void")
+        }
+
+        return arguments.joinToString(", \n")
+    }
+
+    private fun federationRTIProperties(): LinkedHashMap<String, Any> {
+        return tsGenerator.federationRTIPropertiesW()
+    }
+
+    private fun generateSuperConstructorCall(reactor: Reactor, federate: FederateInstance): String {
+        if (reactor.isMain) {
+            return "super(timeout, keepAlive, fast, success, fail);"
+        } else if (reactor.isFederated) {
+            var port = federationRTIProperties()["port"]
+            // Default of 0 is an indicator to use the default port, 15045.
+            if (port == 0) {
+                port = 15045
+            }
+            return """
+            super(${federate.id}, ${port},
+                "${federationRTIProperties()["host"]}",
+                timeout, keepAlive, fast, success, fail);
+            """
+        } else {
+            return "super(parent);"
+        }
+    }
+
+    // If the app is federated, register its
+    // networkMessageActions with the RTIClient
+    private fun generateFederatePortActionRegistrations(networkMessageActions: List<Action>): String {
+        var fedPortID = 0;
+        val connectionInstantiations = LinkedList<String>()
+        for (nAction in networkMessageActions) {
+            val registration = """
+                this.registerFederatePortAction(${fedPortID}, this.${nAction.name});
+                """
+            connectionInstantiations.add(registration)
+            fedPortID++
+        }
+        return connectionInstantiations.joinToString("\n")
+    }
+
+    fun generateConstructor(
+        instances: TSInstanceGenerator,
+        timers: TSTimerGenerator,
+        parameters: TSParameterGenerator,
+        states: TSStateGenerator,
+        actions: TSActionGenerator,
+        ports: TSPortGenerator
+    ): String {
+        val connectionGenerator = TSConnectionGenerator(reactor.connections, errorReporter)
+        val reactionGenerator = TSReactionGenerator(tsGenerator, errorReporter, reactor, federate)
+
+        return with(PrependOperator) {
+            """
+                |constructor (
+            ${" |    "..generateConstructorArguments(reactor)}
+                |) {
+            ${" |    "..generateSuperConstructorCall(reactor, federate)}
+            ${" |    "..instances.generateInstantiations()}
+            ${" |    "..timers.generateInstantiations()}
+            ${" |    "..parameters.generateInstantiations()}
+            ${" |    "..states.generateInstantiations()}
+            ${" |    "..actions.generateInstantiations()}
+            ${" |    "..ports.generateInstantiations()}
+            ${" |    "..connectionGenerator.generateInstantiations()}
+            ${" |    "..if (reactor.isFederated) generateFederatePortActionRegistrations(federate.networkMessageActions) else ""}
+            ${" |    "..reactionGenerator.generateAllReactions()}
+                |}
+            """.trimMargin()
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -160,11 +160,11 @@ class TSGenerator(
 
             val tsCode = StringBuilder()
 
-            val preambleGenerator = TSPreambleGenerator(fileConfig.srcFile,
+            val preambleGenerator = TSImportPreambleGenerator(fileConfig.srcFile,
                 targetConfig.protoFiles)
             tsCode.append(preambleGenerator.generatePreamble())
 
-            val parameterGenerator = TSParameterGenerator(this, fileConfig, targetConfig, reactors)
+            val parameterGenerator = TSParameterPreambleGenerator(this, fileConfig, targetConfig, reactors)
             val (mainParameters, parameterCode) = parameterGenerator.generateParameters()
             tsCode.append(parameterCode)
 

--- a/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSGenerator.kt
@@ -82,10 +82,6 @@ class TSGenerator(
     }
 
     // Wrappers to expose GeneratorBase methods.
-    fun prw(builder: StringBuilder, text: Any) = pr(builder, text)
-    fun indentw(builder: StringBuilder) = indent(builder)
-    fun unindentw(builder: StringBuilder) = unindent(builder)
-
     fun federationRTIPropertiesW() = federationRTIProperties
 
     fun getTargetValueW(v: Value): String = getTargetValue(v)
@@ -170,10 +166,9 @@ class TSGenerator(
 
             val reactorGenerator = TSReactorGenerator(this, errorReporter)
             for (reactor in reactors) {
-                reactorGenerator.generateReactor(reactor, federate)
+                tsCode.append(reactorGenerator.generateReactor(reactor, federate))
             }
-            reactorGenerator.generateReactorInstanceAndStart(this.mainDef, mainParameters)
-            tsCode.append(reactorGenerator.getCode())
+            tsCode.append(reactorGenerator.generateReactorInstanceAndStart(this.mainDef, mainParameters))
             fsa.generateFile(fileConfig.srcGenBasePath.relativize(tsFilePath).toString(),
                 tsCode.toString())
         }

--- a/org.lflang/src/org/lflang/generator/ts/TSImportPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSImportPreambleGenerator.kt
@@ -30,7 +30,7 @@ import java.nio.file.Path
 import java.util.*
 
 /**
- * Preamble generator for TypeScript target.
+ * Preamble generator for imports in TypeScript target.
  *
  *  @author{Matt Weber <matt.weber@berkeley.edu>}
  *  @author{Edward A. Lee <eal@berkeley.edu>}

--- a/org.lflang/src/org/lflang/generator/ts/TSImportPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSImportPreambleGenerator.kt
@@ -39,7 +39,7 @@ import java.util.*
  *  @author {Hokeun Kim <hokeunkim@berkeley.edu>}
  */
 
-class TSPreambleGenerator(
+class TSImportPreambleGenerator(
     private val filePath: Path,
     private val protoFiles: MutableList<String>
 ) {

--- a/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
@@ -47,11 +47,7 @@ class TSInstanceGenerator (
                 childReactor.typeParms.joinToString(", ", "<", ">") { it.toText() }}
             childReactorClassProperties.add("${childReactor.name}: ${childReactor.reactorClass.name}$childReactorParams")
         }
-        return with(PrependOperator) {
-            """
-        ${" |"..childReactorClassProperties.joinToString("\n")}
-        """.trimMargin()
-        }
+        return childReactorClassProperties.joinToString("\n")
     }
 
     fun generateInstantiations(): String {
@@ -71,10 +67,6 @@ class TSInstanceGenerator (
             childReactorInstantiations.add(
                 "this.${childReactor.name} = new ${childReactor.reactorClass.name}($childReactorArguments)")
         }
-        return with(PrependOperator) {
-            """
-        ${" |"..childReactorInstantiations.joinToString("\n")}
-        """.trimMargin()
-        }
+        return childReactorInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
@@ -1,7 +1,6 @@
 package org.lflang.generator.ts
 
 import org.lflang.generator.FederateInstance
-import org.lflang.generator.PrependOperator
 import org.lflang.lf.Instantiation
 import org.lflang.lf.Parameter
 import org.lflang.lf.Reactor
@@ -10,7 +9,7 @@ import org.lflang.toText
 import java.util.*
 
 /**
- * Generator child reactor instantiations in TypeScript target.
+ * Generator for child reactor instantiations in TypeScript target.
  */
 class TSInstanceGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.

--- a/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
@@ -1,0 +1,80 @@
+package org.lflang.generator.ts
+
+import org.lflang.generator.FederateInstance
+import org.lflang.generator.PrependOperator
+import org.lflang.lf.Instantiation
+import org.lflang.lf.Parameter
+import org.lflang.lf.Reactor
+import org.lflang.toDefinition
+import org.lflang.toText
+import java.util.*
+
+/**
+ * Generator child reactor instantiations in TypeScript target.
+ */
+class TSInstanceGenerator (
+    // TODO(hokeun): Remove dependency on TSGenerator.
+    private val tsGenerator: TSGenerator,
+    private val tsReactorGenerator: TSReactorGenerator,
+    private val reactor: Reactor,
+    private val federate: FederateInstance
+) {
+    private val childReactors: List<Instantiation>
+
+    init {
+        // Next handle child reactors instantiations.
+        // If the app isn't federated, instantiate all
+        // the child reactors. If the app is federated
+        if (!reactor.isFederated) {
+            childReactors = reactor.instantiations
+        } else {
+            childReactors = LinkedList<Instantiation>()
+            childReactors.add(federate.instantiation)
+        }
+    }
+
+    private fun getInitializerList(param: Parameter, i: Instantiation): List<String> =
+        tsGenerator.getInitializerListW(param, i)
+
+    private fun getTargetInitializer(param: Parameter, i: Instantiation): String {
+        return tsReactorGenerator.getTargetInitializerHelper(param, getInitializerList(param, i))
+    }
+
+    fun generateClassProperties(): String {
+        val childReactorClassProperties = LinkedList<String>()
+        for (childReactor in childReactors) {
+            val childReactorParams = if (childReactor.typeParms.isEmpty()) {""} else {
+                childReactor.typeParms.joinToString(", ", "<", ">") { it.toText() }}
+            childReactorClassProperties.add("${childReactor.name}: ${childReactor.reactorClass.name}$childReactorParams")
+        }
+        return with(PrependOperator) {
+            """
+        ${" |"..childReactorClassProperties.joinToString("\n")}
+        """.trimMargin()
+        }
+    }
+
+    fun generateInstantiations(): String {
+        val childReactorInstantiations = LinkedList<String>()
+        for (childReactor in childReactors) {
+            val childReactorArguments = StringJoiner(", ");
+            childReactorArguments.add("this")
+
+            // Iterate through parameters in the order they appear in the
+            // reactor class, find the matching parameter assignments in
+            // the reactor instance, and write the corresponding parameter
+            // value as an argument for the TypeScript constructor
+            for (parameter in childReactor.reactorClass.toDefinition().parameters) {
+                childReactorArguments.add(getTargetInitializer(parameter, childReactor))
+            }
+
+            childReactorInstantiations.add(
+                "this.${childReactor.name} = new ${childReactor.reactorClass.name}($childReactorArguments)")
+        }
+        return with(PrependOperator) {
+            """
+        ${" |"..childReactorInstantiations.joinToString("\n")}
+        """.trimMargin()
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSInstanceGenerator.kt
@@ -16,8 +16,8 @@ class TSInstanceGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.
     private val tsGenerator: TSGenerator,
     private val tsReactorGenerator: TSReactorGenerator,
-    private val reactor: Reactor,
-    private val federate: FederateInstance
+    reactor: Reactor,
+    federate: FederateInstance
 ) {
     private val childReactors: List<Instantiation>
 

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterGenerator.kt
@@ -19,11 +19,7 @@ class TSParameterGenerator (
         for (param in parameters) {
             paramClassProperties.add("${param.name}: __Parameter<${param.getTargetType()}>;")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..paramClassProperties.joinToString("\n")}
-            """.trimMargin()
-        }
+        return paramClassProperties.joinToString("\n")
     }
 
     fun generateInstantiations(): String {
@@ -31,10 +27,6 @@ class TSParameterGenerator (
         for (param in parameters) {
             paramInstantiations.add("this.${param.name} = new __Parameter(${param.name});")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..paramInstantiations.joinToString("\n")}
-            """.trimMargin()
-        }
+        return paramInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterGenerator.kt
@@ -1,0 +1,40 @@
+package org.lflang.generator.ts
+
+import org.lflang.generator.PrependOperator
+import org.lflang.lf.Parameter
+import java.util.*
+
+/**
+ * Generate parameters for TypeScript target.
+ */
+class TSParameterGenerator (
+    // TODO(hokeun): Remove dependency on TSGenerator.
+    private val tsGenerator: TSGenerator,
+    private val parameters: List<Parameter>
+ ) {
+    private fun Parameter.getTargetType(): String = tsGenerator.getTargetTypeW(this)
+
+    fun generateClassProperties(): String {
+        val paramClassProperties = LinkedList<String>()
+        for (param in parameters) {
+            paramClassProperties.add("${param.name}: __Parameter<${param.getTargetType()}>;")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..paramClassProperties.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+
+    fun generateInstantiations(): String {
+        val paramInstantiations = LinkedList<String>()
+        for (param in parameters) {
+            paramInstantiations.add("this.${param.name} = new __Parameter(${param.name});")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..paramInstantiations.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
@@ -44,7 +44,7 @@ import java.util.StringJoiner
  *  @author {Hokeun Kim <hokeunkim@berkeley.edu>}
  */
 
-class TSParameterGenerator(
+class TSParameterPreambleGenerator(
     private val tsGenerator: TSGenerator,
     private val fileConfig: FileConfig,
     private val targetConfig: TargetConfig,

--- a/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSParameterPreambleGenerator.kt
@@ -35,7 +35,7 @@ import org.lflang.lf.TimeUnit
 import java.util.StringJoiner
 
 /**
- * Parameter generator for TypeScript target.
+ * Preamble generator for global parameters in TypeScript target.
  *
  *  @author{Matt Weber <matt.weber@berkeley.edu>}
  *  @author{Edward A. Lee <eal@berkeley.edu>}

--- a/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
@@ -41,11 +41,7 @@ class TSPortGenerator (
         for (output in outputs) {
             portClassProperties.add("${output.name}: __OutPort<${getPortType(output)}>;")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..portClassProperties.joinToString("\n")}
-            """.trimMargin()
-        }
+        return portClassProperties.joinToString("\n")
     }
 
     fun generateInstantiations(): String {
@@ -56,10 +52,6 @@ class TSPortGenerator (
         for (output in outputs) {
             porInstantiations.add("this.${output.name} = new __OutPort<${getPortType(output)}>(this);")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..porInstantiations.joinToString("\n")}
-            """.trimMargin()
-        }
+        return porInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
@@ -1,6 +1,5 @@
 package org.lflang.generator.ts
 
-import org.lflang.generator.PrependOperator
 import org.lflang.lf.Input
 import org.lflang.lf.Output
 import org.lflang.lf.Port

--- a/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
@@ -8,7 +8,7 @@ import org.lflang.lf.Type
 import java.util.*
 
 /**
- * Generator input and output ports for TypeScript target.
+ * Generate input and output ports for TypeScript target.
  */
 class TSPortGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.
@@ -36,10 +36,10 @@ class TSPortGenerator (
     fun generateClassProperties(): String {
         val portClassProperties = LinkedList<String>()
         for (input in inputs) {
-            portClassProperties.add(input.name + ": " + "__InPort<" + getPortType(input) + ">;")
+            portClassProperties.add("${input.name}: __InPort<${getPortType(input)}>;")
         }
         for (output in outputs) {
-            portClassProperties.add(output.name + ": " + "__OutPort<" + getPortType(output) + ">;")
+            portClassProperties.add("${output.name}: __OutPort<${getPortType(output)}>;")
         }
         return with(PrependOperator) {
             """
@@ -51,12 +51,10 @@ class TSPortGenerator (
     fun generateInstantiations(): String {
         val porInstantiations = LinkedList<String>()
         for (input in inputs) {
-            porInstantiations.add("this." + input.name + " = new __InPort<"
-                    + getPortType(input) + ">(this);")
+            porInstantiations.add("this.${input.name} = new __InPort<${getPortType(input)}>(this);")
         }
         for (output in outputs) {
-            porInstantiations.add("this." + output.name + " = new __OutPort<"
-                    + getPortType(output) + ">(this);")
+            porInstantiations.add("this.${output.name} = new __OutPort<${getPortType(output)}>(this);")
         }
         return with(PrependOperator) {
             """

--- a/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSPortGenerator.kt
@@ -1,0 +1,67 @@
+package org.lflang.generator.ts
+
+import org.lflang.generator.PrependOperator
+import org.lflang.lf.Input
+import org.lflang.lf.Output
+import org.lflang.lf.Port
+import org.lflang.lf.Type
+import java.util.*
+
+/**
+ * Generator input and output ports for TypeScript target.
+ */
+class TSPortGenerator (
+    // TODO(hokeun): Remove dependency on TSGenerator.
+    private val tsGenerator: TSGenerator,
+    private val inputs: List<Input>,
+    private val outputs: List<Output>
+) {
+    private fun Type.getTargetType(): String = tsGenerator.getTargetTypeW(this)
+
+    /**
+     * Return a TS type for the specified port.
+     * If the type has not been specified, return
+     * "Present" which is the base type for ports.
+     * @param port The port
+     * @return The TS type.
+     */
+    private fun getPortType(port: Port): String {
+        if (port.type != null) {
+            return port.type.getTargetType()
+        } else {
+            return "Present"
+        }
+    }
+
+    fun generateClassProperties(): String {
+        val portClassProperties = LinkedList<String>()
+        for (input in inputs) {
+            portClassProperties.add(input.name + ": " + "__InPort<" + getPortType(input) + ">;")
+        }
+        for (output in outputs) {
+            portClassProperties.add(output.name + ": " + "__OutPort<" + getPortType(output) + ">;")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..portClassProperties.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+
+    fun generateInstantiations(): String {
+        val porInstantiations = LinkedList<String>()
+        for (input in inputs) {
+            porInstantiations.add("this." + input.name + " = new __InPort<"
+                    + getPortType(input) + ">(this);")
+        }
+        for (output in outputs) {
+            porInstantiations.add("this." + output.name + " = new __OutPort<"
+                    + getPortType(output) + ">(this);")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..porInstantiations.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -4,6 +4,7 @@ import org.lflang.*
 import org.lflang.generator.FederateInstance
 import org.lflang.generator.PrependOperator
 import org.lflang.lf.*
+import org.lflang.lf.Timer
 import java.lang.StringBuilder
 import java.util.*
 import kotlin.collections.LinkedHashMap
@@ -195,16 +196,9 @@ class TSReactorGenerator(
                     "(" + childReactorArguments + ")" )
         }
 
-        // Next handle timers.
-        for (timer in reactor.timers) {
-            val timerPeriod: String = timer.period?.getTargetValue() ?: "0"
-            val timerOffset: String = timer.offset?.getTargetValue() ?: "0"
-
-            pr(timer.name + ": __Timer;")
-            pr(reactorConstructor, "this." + timer.name
-                    + " = new __Timer(this, " + timerOffset + ", "+ timerPeriod + ");")
-
-        }
+        var timerGenerator = TSTimerGenerator(tsGenerator, reactor.timers)
+        pr(timerGenerator.generateClassProperties())
+        pr(reactorConstructor, timerGenerator.generateInstantiations())
 
         // Create properties for parameters
         for (param in reactor.parameters) {
@@ -213,11 +207,11 @@ class TSReactorGenerator(
                     " = new __Parameter(" + param.name + ");" )
         }
 
-        val stateGenerator = TSStateGenerator(tsGenerator, reactor)
+        val stateGenerator = TSStateGenerator(tsGenerator, reactor.stateVars)
         pr(stateGenerator.generateClassProperties())
         pr(reactorConstructor, stateGenerator.generateInstantiations())
 
-        val actionGenerator = TSActionGenerator(tsGenerator, reactor)
+        val actionGenerator = TSActionGenerator(tsGenerator, reactor.actions)
         pr(actionGenerator.generateClassProperties())
         pr(reactorConstructor, actionGenerator.generateInstantiations())
 

--- a/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -34,7 +34,6 @@ class TSReactorGenerator(
     private fun indent() = indent(code)
     private fun unindent() = unindent(code)
 
-    private fun pr(builder: StringBuilder, text: Any) = tsGenerator.prw(builder, text)
     private fun pr(text: Any) = tsGenerator.prw(code, text)
 
     private fun Parameter.getTargetType(): String = tsGenerator.getTargetTypeW(this)
@@ -84,12 +83,7 @@ class TSReactorGenerator(
             arguments.add("fail?: () => void")
         }
 
-        return with(PrependOperator) {
-            """
-                |constructor (
-            ${" |    "..arguments.joinToString(", \n")}
-                |)
-            """.trimMargin()}
+        return arguments.joinToString(", \n")
     }
 
     // If the app is federated, register its
@@ -174,28 +168,25 @@ class TSReactorGenerator(
         val connectionGenerator = TSConnectionGenerator(reactor.connections, errorReporter)
         val reactionGenerator = TSReactionGenerator(tsGenerator, errorReporter, reactor, federate)
 
-        val reactorConstructor = StringBuilder()
-        pr(reactorConstructor, "${generateConstructorArguments(reactor)} {")
-        indent(reactorConstructor)
-        
-        pr(reactorConstructor, with(PrependOperator) {
+        pr(with(PrependOperator) {
             """
-            ${" |"..generateSuperConstructorCall(reactor, federate)}
-            ${" |"..instanceGenerator.generateInstantiations()}
-            ${" |"..timerGenerator.generateInstantiations()}
-            ${" |"..parameterGenerator.generateInstantiations()}
-            ${" |"..stateGenerator.generateInstantiations()}
-            ${" |"..actionGenerator.generateInstantiations()}
-            ${" |"..portGenerator.generateInstantiations()}
-            ${" |"..connectionGenerator.generateInstantiations()}
-            ${" |"..if (reactor.isFederated) generateFederatePortActionRegistrations(federate.networkMessageActions) else ""}
-            ${" |"..reactionGenerator.generateAllReactions()}
+                |constructor (
+            ${" |    "..generateConstructorArguments(reactor)}
+                |) {
+            ${" |    "..generateSuperConstructorCall(reactor, federate)}
+            ${" |    "..instanceGenerator.generateInstantiations()}
+            ${" |    "..timerGenerator.generateInstantiations()}
+            ${" |    "..parameterGenerator.generateInstantiations()}
+            ${" |    "..stateGenerator.generateInstantiations()}
+            ${" |    "..actionGenerator.generateInstantiations()}
+            ${" |    "..portGenerator.generateInstantiations()}
+            ${" |    "..connectionGenerator.generateInstantiations()}
+            ${" |    "..if (reactor.isFederated) generateFederatePortActionRegistrations(federate.networkMessageActions) else ""}
+            ${" |    "..reactionGenerator.generateAllReactions()}
+                |}
             """.trimMargin()
         })
 
-        unindent(reactorConstructor)
-        pr(reactorConstructor, "}")
-        pr(reactorConstructor.toString())
         unindent()
         pr("}")
         pr("// =============== END reactor class " + reactor.name)

--- a/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -283,7 +283,7 @@ class TSReactorGenerator(
      *  main one.
      *  @param instance A reactor instance.
      */
-    fun generateReactorInstance(defn: Instantiation, mainParameters: Set<Parameter>) {
+    fun generateReactorInstance(defn: Instantiation, mainParameters: Set<Parameter>): String {
         val fullName = defn.name
 
         // Iterate through parameters in the order they appear in the
@@ -302,25 +302,23 @@ class TSReactorGenerator(
             }
         }
 
-        pr("// ************* Instance " + fullName + " of class " +
-                defn.reactorClass.name)
-
-        pr("let __app;")
-        pr("if (!__noStart) {")
-        indent()
-        pr("__app = new "+ fullName + "(__timeout, __keepAlive, __fast, "
-                + mainReactorParams + ");")
-        unindent()
-        pr("}")
+        return with(PrependOperator) {
+            """
+            |// ************* Instance $fullName of class ${defn.reactorClass.name}
+            |let __app;
+            |if (!__noStart) {
+            |    __app = new $fullName(__timeout, __keepAlive, __fast, $mainReactorParams);
+            |}
+            """
+        }.trimMargin()
     }
 
     /** Generate code to call the _start function on the main App
      *  instance to start the runtime
      *  @param instance A reactor instance.
      */
-    private fun generateRuntimeStart(defn: Instantiation) {
-        pr(
-            with(PrependOperator) {
+    private fun generateRuntimeStart(defn: Instantiation): String {
+        return with(PrependOperator) {
                 """
             |// ************* Starting Runtime for ${defn.name} + of class ${defn.reactorClass.name}.
             |if (!__noStart && __app) {
@@ -328,7 +326,6 @@ class TSReactorGenerator(
             |}
             """
             }.trimMargin()
-        )
     }
 
     fun generateReactor(reactor: Reactor, federate: FederateInstance) {
@@ -336,8 +333,8 @@ class TSReactorGenerator(
     }
 
     fun generateReactorInstanceAndStart(mainDef: Instantiation, mainParameters: Set<Parameter>) {
-        generateReactorInstance(mainDef, mainParameters)
-        generateRuntimeStart(mainDef)
+        pr(generateReactorInstance(mainDef, mainParameters))
+        pr(generateRuntimeStart(mainDef))
     }
 
     fun getCode(): String {

--- a/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -143,38 +143,33 @@ class TSReactorGenerator(
         pr(reactorConstructor, superCall)
 
         var instanceGenerator = TSInstanceGenerator(tsGenerator, this, reactor, federate)
-        pr(instanceGenerator.generateClassProperties())
-        pr(reactorConstructor, instanceGenerator.generateInstantiations())
+        var timerGenerator = TSTimerGenerator(tsGenerator, reactor.timers)
+        var parameterGenerator = TSParameterGenerator(tsGenerator, reactor.parameters)
+        val stateGenerator = TSStateGenerator(tsGenerator, reactor.stateVars)
+        val actionGenerator = TSActionGenerator(tsGenerator, reactor.actions)
+        val portGenerator = TSPortGenerator(tsGenerator, reactor.inputs, reactor.outputs)
 
-        if (!reactor.timers.isEmpty()) {
-            var timerGenerator = TSTimerGenerator(tsGenerator, reactor.timers)
-            pr(timerGenerator.generateClassProperties())
-            pr(reactorConstructor, timerGenerator.generateInstantiations())
-        }
+        pr(with(PrependOperator) {
+            """
+            ${" |"..instanceGenerator.generateClassProperties()}
+            ${" |"..timerGenerator.generateClassProperties()}
+            ${" |"..parameterGenerator.generateClassProperties()}
+            ${" |"..stateGenerator.generateClassProperties()}
+            ${" |"..actionGenerator.generateClassProperties()}
+            ${" |"..portGenerator.generateClassProperties()}
+            """.trimMargin()
+        })
 
-        if (!reactor.parameters.isEmpty()) {
-            var parameterGenerator = TSParameterGenerator(tsGenerator, reactor.parameters)
-            pr(parameterGenerator.generateClassProperties())
-            pr(reactorConstructor, parameterGenerator.generateInstantiations())
-        }
-
-        if (!reactor.stateVars.isEmpty()) {
-            val stateGenerator = TSStateGenerator(tsGenerator, reactor.stateVars)
-            pr(stateGenerator.generateClassProperties())
-            pr(reactorConstructor, stateGenerator.generateInstantiations())
-        }
-
-        if (!reactor.actions.isEmpty()) {
-            val actionGenerator = TSActionGenerator(tsGenerator, reactor.actions)
-            pr(actionGenerator.generateClassProperties())
-            pr(reactorConstructor, actionGenerator.generateInstantiations())
-        }
-
-        if (!reactor.inputs.isEmpty() || !reactor.outputs.isEmpty()) {
-            val portGenerator = TSPortGenerator(tsGenerator, reactor.inputs, reactor.outputs)
-            pr(portGenerator.generateClassProperties())
-            pr(reactorConstructor, portGenerator.generateInstantiations())
-        }
+        pr(reactorConstructor, with(PrependOperator) {
+            """
+            ${" |"..instanceGenerator.generateInstantiations()}
+            ${" |"..timerGenerator.generateInstantiations()}
+            ${" |"..parameterGenerator.generateInstantiations()}
+            ${" |"..stateGenerator.generateInstantiations()}
+            ${" |"..actionGenerator.generateInstantiations()}
+            ${" |"..portGenerator.generateInstantiations()}
+            """.trimMargin()
+        })
 
         // Next handle connections
         for (connection in reactor.connections) {

--- a/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSReactorGenerator.kt
@@ -48,7 +48,7 @@ class TSReactorGenerator(
     }
 
     // Initializer functions
-    public fun getTargetInitializerHelper(param: Parameter,
+    fun getTargetInitializerHelper(param: Parameter,
                                            list: List<String>): String {
         return if (list.size == 0) {
             errorReporter.reportError(param, "Parameters must have a default value!")
@@ -152,12 +152,10 @@ class TSReactorGenerator(
             pr(reactorConstructor, timerGenerator.generateInstantiations())
         }
 
-        // Create properties for parameters
-        for (param in reactor.parameters) {
-            pr(param.name + ": __Parameter<" + param.getTargetType() + ">;")
-            pr(reactorConstructor, "this." + param.name +
-                        " = new __Parameter(" + param.name + ");"
-            )
+        if (!reactor.parameters.isEmpty()) {
+            var parameterGenerator = TSParameterGenerator(tsGenerator, reactor.parameters)
+            pr(parameterGenerator.generateClassProperties())
+            pr(reactorConstructor, parameterGenerator.generateInstantiations())
         }
 
         if (!reactor.stateVars.isEmpty()) {

--- a/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
@@ -2,19 +2,18 @@ package org.lflang.generator.ts
 
 import org.lflang.ASTUtils
 import org.lflang.generator.PrependOperator
-import org.lflang.lf.Reactor
 import org.lflang.lf.StateVar
 import java.util.*
 
 class TSStateGenerator (
     private val tsGenerator: TSGenerator,
-    private val reactor: Reactor
+    private val stateVars: List<StateVar>
 ) {
     private fun StateVar.getTargetType(): String = tsGenerator.getTargetTypeW(this)
 
     fun generateClassProperties(): String {
         val stateClassProperties = LinkedList<String>()
-        for (stateVar in reactor.stateVars) {
+        for (stateVar in stateVars) {
             stateClassProperties.add("${stateVar.name}: __State<${stateVar.getTargetType()}>;");
         }
         return with(PrependOperator) {
@@ -33,7 +32,7 @@ class TSStateGenerator (
     fun generateInstantiations(): String {
         val stateInstantiations = LinkedList<String>()
         // Next handle states.
-        for (stateVar in reactor.stateVars) {
+        for (stateVar in stateVars) {
             if (ASTUtils.isInitialized(stateVar)) {
                 stateInstantiations.add("this.${stateVar.name} = new __State(${getTargetInitializer(stateVar)});");
             } else {

--- a/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
@@ -5,6 +5,9 @@ import org.lflang.generator.PrependOperator
 import org.lflang.lf.StateVar
 import java.util.*
 
+/**
+ * Generator for state variables in TypeScript target.
+ */
 class TSStateGenerator (
     private val tsGenerator: TSGenerator,
     private val stateVars: List<StateVar>

--- a/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSStateGenerator.kt
@@ -16,11 +16,7 @@ class TSStateGenerator (
         for (stateVar in stateVars) {
             stateClassProperties.add("${stateVar.name}: __State<${stateVar.getTargetType()}>;");
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..stateClassProperties.joinToString("\n")}
-            """.trimMargin()
-        }
+        return stateClassProperties.joinToString("\n")
     }
 
     private fun getInitializerList(state: StateVar): List<String> =
@@ -39,10 +35,6 @@ class TSStateGenerator (
                 stateInstantiations.add("this.${stateVar.name} = new __State(undefined);");
             }
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..stateInstantiations.joinToString("\n")}
-            """.trimMargin()
-        }
+        return stateInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
@@ -1,0 +1,41 @@
+package org.lflang.generator.ts;
+
+import org.lflang.generator.PrependOperator
+import org.lflang.lf.Timer
+import org.lflang.lf.Value
+import java.util.*
+
+class TSTimerGenerator (
+    // TODO(hokeun): Remove dependency on TSGenerator.
+    private val tsGenerator: TSGenerator,
+    private val timers:List<Timer>
+) {
+    private fun Value.getTargetValue(): String = tsGenerator.getTargetValueW(this)
+
+    fun generateClassProperties(): String {
+        val timerClassProperties = LinkedList<String>()
+        for (timer in timers) {
+            timerClassProperties.add("${timer.name}: __Timer;")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..timerClassProperties.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+
+    fun generateInstantiations(): String {
+        val timerInstantiations = LinkedList<String>()
+        for (timer in timers) {
+            val timerPeriod: String = timer.period?.getTargetValue() ?: "0"
+            val timerOffset: String = timer.offset?.getTargetValue() ?: "0"
+
+            timerInstantiations.add("this.${timer.name} = new __Timer(this, $timerOffset, $timerPeriod);")
+        }
+        return with(PrependOperator) {
+            """
+            ${" |"..timerInstantiations.joinToString("\n")}
+            """.trimMargin()
+        }
+    }
+}

--- a/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
@@ -20,11 +20,7 @@ class TSTimerGenerator (
         for (timer in timers) {
             timerClassProperties.add("${timer.name}: __Timer;")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..timerClassProperties.joinToString("\n")}
-            """.trimMargin()
-        }
+        return timerClassProperties.joinToString("\n")
     }
 
     fun generateInstantiations(): String {
@@ -35,10 +31,6 @@ class TSTimerGenerator (
 
             timerInstantiations.add("this.${timer.name} = new __Timer(this, $timerOffset, $timerPeriod);")
         }
-        return with(PrependOperator) {
-            """
-            ${" |"..timerInstantiations.joinToString("\n")}
-            """.trimMargin()
-        }
+        return timerInstantiations.joinToString("\n")
     }
 }

--- a/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
+++ b/org.lflang/src/org/lflang/generator/ts/TSTimerGenerator.kt
@@ -5,10 +5,13 @@ import org.lflang.lf.Timer
 import org.lflang.lf.Value
 import java.util.*
 
+/**
+ * Generator timers for TypeScript target.
+ */
 class TSTimerGenerator (
     // TODO(hokeun): Remove dependency on TSGenerator.
     private val tsGenerator: TSGenerator,
-    private val timers:List<Timer>
+    private val timers: List<Timer>
 ) {
     private fun Value.getTargetValue(): String = tsGenerator.getTargetValueW(this)
 


### PR DESCRIPTION
TSReactorGenerator got much shorter: 378 lines -> 154 lines