### PR TITLE
Test all the benchmarks with GitHubActions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         run: pip3 install -r benchmark/runner/requirements.txt      
       - name: Build lfc;
         run: |
-          ./gradlew generateStandaloneComiler
+          ./gradlew generateStandaloneCompiler
       - name: "Set LF_PATH environmental variable"
         run: |
           echo "LF_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -215,8 +215,6 @@ jobs:
   
   benchmark-tests:
     runs-on: ubuntu-latest
-    env:
-      LF_PATH: ${{ env.GITHUB_WORKSPACE }}
     steps:
       - name: Setup Java JDK
         uses: actions/setup-java@v1.4.3
@@ -232,6 +230,9 @@ jobs:
       - name: Build lfc;
         run: |
           ./gradlew generateStandaloneComiler
+      - name: "Set LF_PATH environmental variable"
+        run: |
+          echo "LF_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
       # this tests all benchmarks for all lf targets
       - name: run tests;
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,8 @@ jobs:
       - name: Run Python tests;
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
-
+  
+  benchmark-tests:
     runs-on: ubuntu-latest
     env:
       LF_PATH: ${{ env.GITHUB_WORKSPACE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,4 +213,28 @@ jobs:
         run: |
           ./gradlew test --tests org.lflang.tests.runtime.PythonTest.*
 
+    runs-on: ubuntu-latest
+    env:
+      LF_PATH: ${{ env.GITHUB_WORKSPACE }}
+    steps:
+      - name: Setup Java JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          # The Java version to make available on the path. Takes a whole or semver Java version, or 1.x syntax (e.g. 1.8 => Java 8.x). Early access versions can be specified in the form of e.g. 14-ea, 14.0.0-ea, or 14.0.0-ea.28
+          java-version: 14
+      - name: Setup Python
+        uses: actions/setup-python@v2
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2      
+      - name: Install python dependencies
+        run: pip3 install -r benchmark/runner/requirements.txt      
+      - name: Build lfc;
+        run: |
+          ./gradlew generateStandaloneComiler
+      # this tests all benchmarks for all lf targets
+      - name: run tests;
+        run: |
+          python3 benchmark/runner/run_benchmark.py -m test_mode=True iterations=1 benchmark="glob(*)" target="glob(lf-*)" iterations=1
+      
+
     

--- a/benchmark/runner/conf/benchmark/savina_micro_pingpong.yaml
+++ b/benchmark/runner/conf/benchmark/savina_micro_pingpong.yaml
@@ -25,8 +25,8 @@ targets:
       pings: ["--count", "<value>"]
   lf-c:
     copy_sources:
-      - "${lf_path}/benchmark/C/Savina/PingPongGenerator.lf"
-    lf_file: "PingPongGenerator.lf"
-    binary: "PingPongGenerator"
+      - "${lf_path}/benchmark/C/Savina/src/micro/PingPong.lf"
+    lf_file: "PingPong.lf"
+    binary: "PingPong"
     gen_args:
       pings: ["-D", "count=<value>"]

--- a/benchmark/runner/conf/default.yaml
+++ b/benchmark/runner/conf/default.yaml
@@ -3,6 +3,7 @@ threads: null
 savina_path: "${oc.env:SAVINA_PATH}"
 lf_path: "${oc.env:LF_PATH}"
 continue_on_error: False
+test_mode: False
 defaults:
   - benchmark: ???
   - target: ???

--- a/benchmark/runner/run_benchmark.py
+++ b/benchmark/runner/run_benchmark.py
@@ -50,11 +50,18 @@ def main(cfg):
 
     log.info(f"Running {benchmark_name} using the {target_name} target.")
 
+
+
     # perform some sanity checks
     if "validation_alias" in target:
         target_validation_name = target["validation_alias"]
     else:
         target_validation_name = target_name
+
+    if target_name not in benchmark["targets"]:
+        log.warning(f"target {target_name} is not supported by the benchmark {benchmark_name}")
+        return
+
     if not check_benchmark_target_config(benchmark, target_validation_name):
         if continue_on_error:
             return
@@ -103,9 +110,6 @@ def check_return_code(code, continue_on_error):
 
 def check_benchmark_target_config(benchmark, target_name):
     benchmark_name = benchmark["name"]
-    if target_name not in benchmark["targets"]:
-        log.error(f"target {target_name} is not supported by the benchmark {benchmark_name}")
-        return False
     # keep a list of all benchmark parameters
     bench_params = list(benchmark["params"].keys())
 


### PR DESCRIPTION
This extends the benchmark runner by a 'test mode'. In this mode, it builds and runs all the benchmarks as normal, but uses a timeout for the actual benchmark run. This way, we can test if everything works as expected, without waiting for a potential lengthy benchmark run to complete.

I think that this way of testing via the benchmark runner should be preferred over an integration of the benchmarks with our Java based test setup. This way of testing via the runner not only tests the LF benchmarks, but more importantly also the benchmark runner and the provided configurations.

This PR depends on #504.

Closes #439 