### PR TITLE
SVG Export for Epoch RCA

### DIFF
--- a/org.lflang.rca/lflang.product
+++ b/org.lflang.rca/lflang.product
@@ -102,7 +102,9 @@ OF SUCH DAMAGE.
       <feature id="org.eclipse.cdt"/>
       <feature id="org.python.pydev.feature"/>
       <feature id="de.cau.cs.kieler.klighd.view.feature"/>
+      <feature id="de.cau.cs.kieler.klighd.freehep.feature"/>
       <feature id="org.eclipse.tm.terminal.feature"/>
+      <feature id="org.eclipse.epp.mpc"/>
    </features>
 
    <configurations>


### PR DESCRIPTION
Adds support for SVG export of diagrams to the Epoch RCA.

Also includes the Eclipse Marketplace in the product.